### PR TITLE
Add dagger and dependency injection

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,6 +23,7 @@ if (flutterVersionName == null) {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
@@ -70,4 +71,6 @@ dependencies {
     releaseImplementation "io.rebble.libpebblecommon:libpebblecommon-android:$libpebblecommon_version"
     debugImplementation "io.rebble.libpebblecommon:libpebblecommon-android-debug:$libpebblecommon_version"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
+    implementation 'com.google.dagger:dagger:2.29.1'
+    kapt 'com.google.dagger:dagger-compiler:2.29.1'
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -53,6 +53,11 @@ android {
         }
     }
 }
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    }
+}
 
 flutter {
     source '../..'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,10 +64,12 @@ flutter {
     source '../..'
 }
 
-def libpebblecommon_version = '0.0.5'
+def libpebblecommon_version = '0.0.6'
+def coroutinesVersion = "1.3.9"
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     releaseImplementation "io.rebble.libpebblecommon:libpebblecommon-android:$libpebblecommon_version"
     debugImplementation "io.rebble.libpebblecommon:libpebblecommon-android-debug:$libpebblecommon_version"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name=".FossilApplication"
         android:label="fossil"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round">

--- a/android/app/src/main/kotlin/io/rebble/fossil/BlueCommon.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/BlueCommon.kt
@@ -58,7 +58,11 @@ class BlueCommon(private val context: Context, private val packetCallback: (Byte
                     Log.d(logTag, "Scanning ended")
                     isScanning = false
                     bluetoothAdapter.cancelDiscovery()
-                    context.unregisterReceiver(this)
+                    try {
+                        context.unregisterReceiver(this)
+                    } catch (e: IllegalArgumentException) {
+                        // Receiver was not registered in the first place. Do nothing.
+                    }
                     resultCallback(pebbleList)
                 }else {
                     scanRetries++

--- a/android/app/src/main/kotlin/io/rebble/fossil/BlueCommon.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/BlueCommon.kt
@@ -7,8 +7,12 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Handler
 import io.flutter.Log
+import io.rebble.libpebblecommon.BluetoothConnection
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class BlueCommon(private val context: Context, private val packetCallback: (ByteArray) -> Unit) : BroadcastReceiver() {
+@Singleton
+class BlueCommon @Inject constructor(private val context: Context) : BroadcastReceiver(), BluetoothConnection {
     private val logTag = "BlueCommon"
 
     val bluetoothAdapter = android.bluetooth.BluetoothAdapter.getDefaultAdapter()
@@ -19,6 +23,8 @@ class BlueCommon(private val context: Context, private val packetCallback: (Byte
     private var isScanning = false
     private var scanRetries = 0
     private var onConChange: ((Boolean) -> Unit)? = null
+
+    private var externalIncomingPacketHandler: (suspend (ByteArray) -> Unit)? = null
 
     override fun onReceive(context: Context, intent: Intent) {
         when(intent.action!!) {
@@ -90,7 +96,7 @@ class BlueCommon(private val context: Context, private val packetCallback: (Byte
                 TODO("BLE")
             }
             device.type != BluetoothDevice.DEVICE_TYPE_UNKNOWN -> { // Serial only device or serial/LE
-                driver = BlueSerial(bluetoothAdapter, context, packetCallback)
+                driver = BlueSerial(bluetoothAdapter, context, this::handlePacketReceivedFromDriver)
                 onConChange?.let { driver!!.setOnConnectionChange(it) }
                 driver!!.targetPebble(device)
             }
@@ -101,5 +107,17 @@ class BlueCommon(private val context: Context, private val packetCallback: (Byte
     fun setOnConnectionChange(f: (Boolean) -> Unit) {
         onConChange = f
         driver?.setOnConnectionChange(f)
+    }
+
+    override suspend fun sendPacket(data: ByteArray) {
+        driver?.sendPacket(data)
+    }
+
+    override fun setReceiveCallback(callback: suspend (ByteArray) -> Unit) {
+        externalIncomingPacketHandler = callback
+    }
+
+    private suspend fun handlePacketReceivedFromDriver(packet: ByteArray) {
+        externalIncomingPacketHandler?.invoke(packet)
     }
 }

--- a/android/app/src/main/kotlin/io/rebble/fossil/BlueIO.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/BlueIO.kt
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer
 interface BlueIO {
     val isConnected: Boolean
 
-    fun sendPacket(bytes: ByteArray)
+    suspend fun sendPacket(bytes: ByteArray)
     fun readStream(buffer: ByteBuffer, offset: Int, count: Int): Int
     fun targetPebble(device: BluetoothDevice): Boolean
     fun closePebble()

--- a/android/app/src/main/kotlin/io/rebble/fossil/FossilApplication.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/FossilApplication.kt
@@ -1,0 +1,18 @@
+package io.rebble.fossil
+
+import android.app.Application
+import io.flutter.app.FlutterApplication
+import io.rebble.fossil.di.AppComponent
+import io.rebble.fossil.di.AppModule
+import io.rebble.fossil.di.DaggerAppComponent
+
+class FossilApplication: FlutterApplication() {
+    lateinit var component: AppComponent
+        private set
+
+    override fun onCreate() {
+        component = DaggerAppComponent.factory().build(this)
+
+        super.onCreate()
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/MainActivity.kt
@@ -22,6 +22,8 @@ import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugins.GeneratedPluginRegistrant
+import io.rebble.libpebblecommon.blobdb.PushNotification
+import io.rebble.libpebblecommon.services.notification.NotificationService
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.URI
@@ -183,11 +185,13 @@ class MainActivity: FlutterActivity() {
 
     var deviceList: List<BluetoothDevice> = listOf()
 
+    @OptIn(ExperimentalStdlibApi::class)
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         val flutter = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "io.rebble.fossil/protocol")
         val scanEvent = EventChannel(flutterEngine.dartExecutor.binaryMessenger, "io.rebble.fossil/scanEvent")
         val packetIO = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "io.rebble.fossil/packetIO")
         val bootWaiter = MethodChannel(flutterEngine.dartExecutor.binaryMessenger,"io.rebble.fossil/bootWaiter")
+        val notificationTester = MethodChannel(flutterEngine.dartExecutor.binaryMessenger,"io.rebble.fossil/notificationTest")
 
         scanEvent.setStreamHandler(object : EventChannel.StreamHandler {
             override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
@@ -228,6 +232,19 @@ class MainActivity: FlutterActivity() {
                         result.success(success)
                         bootIntentCallback = null
                     }
+            }
+        }
+
+        notificationTester.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "sendTestNotification" -> {
+                    NotificationService.send(
+                            PushNotification(
+                                    "Test Notification"
+
+                            )
+                    ) {}
+                }
             }
         }
     }

--- a/android/app/src/main/kotlin/io/rebble/fossil/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/MainActivity.kt
@@ -24,6 +24,8 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugins.GeneratedPluginRegistrant
 import io.rebble.libpebblecommon.blobdb.PushNotification
 import io.rebble.libpebblecommon.services.notification.NotificationService
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.URI
@@ -238,12 +240,16 @@ class MainActivity: FlutterActivity() {
         notificationTester.setMethodCallHandler { call, result ->
             when (call.method) {
                 "sendTestNotification" -> {
-                    NotificationService.send(
-                            PushNotification(
-                                    "Test Notification"
+                    GlobalScope.launch {
+                        watchService?.notificationService?.send(
+                                PushNotification(
+                                        "Test Notification"
 
-                            )
-                    ) {}
+                                )
+                        )
+
+                        println("Notification sent")
+                    }
                 }
             }
         }

--- a/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
@@ -73,7 +73,10 @@ class WatchService : Service() {
 
     @ExperimentalStdlibApi
     override fun onCreate() {
+        val injectionComponent = (applicationContext as FossilApplication).component
+
         super.onCreate()
+
         // TODO: BLE
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (this.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {

--- a/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
@@ -1,8 +1,6 @@
 package io.rebble.fossil
 
 import android.Manifest
-import android.app.AlertDialog
-import android.app.Notification
 import android.app.Service
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
@@ -11,9 +9,7 @@ import android.content.pm.PackageManager
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
-import android.provider.Settings
 import android.provider.Telephony
-import android.text.TextUtils
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -23,6 +19,8 @@ import io.rebble.libpebblecommon.ProtocolHandler
 import io.rebble.libpebblecommon.blobdb.NotificationSource
 import io.rebble.libpebblecommon.blobdb.PushNotification
 import io.rebble.libpebblecommon.services.notification.NotificationService
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 
 @ExperimentalUnsignedTypes
@@ -30,11 +28,11 @@ class WatchService : Service() {
     private val pBinder = ProtBinder()
     private val logTag: String = "FossilWatchService"
     private val bluetoothAdapter: BluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
-    private var protocolHandler: ProtocolHandler? = null
 
-    private val blueCommon = BlueCommon(this) {
-        protocolHandler?.handle(it)
-    }
+    private lateinit var protocolHandler: ProtocolHandler
+    private lateinit var blueCommon: BlueCommon
+    lateinit var notificationService: NotificationService
+        private set
 
     private val mainNotifBuilder = NotificationCompat.Builder(this, "device_status")
             .setContentTitle("Disconnected")
@@ -65,8 +63,10 @@ class WatchService : Service() {
     private val notifBroadcastReceiver = object: BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             val notif = intent?.getBundleExtra("notification") ?: return
-            NotificationService.send(PushNotification(notif["subject"] as String, notif["sender"] as String, notif["content"] as String, packageToSource(notif["pkg"] as String))) {
-                Log.d("FossilNotifRet", "Got resp from BlobDB: ${it::class.simpleName}")
+            //TODO centralize coroutine creation
+            GlobalScope.launch {
+                val res = notificationService.send(PushNotification(notif["subject"] as String, notif["sender"] as String, notif["content"] as String, packageToSource(notif["pkg"] as String)))
+                Log.d("FossilNotifRet", "Got resp from BlobDB: ${res::class.simpleName}")
             }
         }
     }
@@ -74,6 +74,10 @@ class WatchService : Service() {
     @ExperimentalStdlibApi
     override fun onCreate() {
         val injectionComponent = (applicationContext as FossilApplication).component
+
+        blueCommon = injectionComponent.createBlueCommon()
+        notificationService = injectionComponent.createNotificationService()
+        protocolHandler = injectionComponent.createProtocolHandler()
 
         super.onCreate()
 
@@ -91,9 +95,7 @@ class WatchService : Service() {
         }
         LocalBroadcastManager.getInstance(applicationContext).registerReceiver(notifBroadcastReceiver, IntentFilter("io.rebble.fossil.NOTIFICATION_BROADCAST"))
 
-        startIO { res ->
-            protocolHandler?.handle(res)
-        }
+        startIO()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -110,8 +112,7 @@ class WatchService : Service() {
         NotificationManagerCompat.from(this).notify(1, mainNotifBuilder.build())
     }
 
-    private fun startIO(packetCallback: (ByteArray) -> Unit) {
-        protocolHandler = ProtocolHandler {bytes -> blueCommon.driver?.sendPacket(bytes)}
+    private fun startIO() {
         blueCommon.setOnConnectionChange { connected -> setNotification(connected) }
     }
 
@@ -130,7 +131,9 @@ class WatchService : Service() {
     }
 
     fun sendDevPacket(packet: ByteArray) {
-        blueCommon.driver?.sendPacket(packet)
+        GlobalScope.launch {
+            blueCommon.driver?.sendPacket(packet)
+        }
     }
 
     fun isConnected(): Boolean {

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/AppComponent.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/AppComponent.kt
@@ -1,0 +1,15 @@
+package io.rebble.fossil.di
+
+import android.app.Application
+import dagger.BindsInstance
+import dagger.Component
+
+@Component(modules = [
+    AppModule::class
+])
+interface AppComponent {
+    @Component.Factory
+    interface Factory {
+        fun build(@BindsInstance application: Application): AppComponent
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/AppComponent.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/AppComponent.kt
@@ -3,11 +3,21 @@ package io.rebble.fossil.di
 import android.app.Application
 import dagger.BindsInstance
 import dagger.Component
+import io.rebble.fossil.BlueCommon
+import io.rebble.libpebblecommon.ProtocolHandler
+import io.rebble.libpebblecommon.services.notification.NotificationService
+import javax.inject.Singleton
 
+@Singleton
 @Component(modules = [
-    AppModule::class
+    AppModule::class,
+    LibPebbleModule::class
 ])
 interface AppComponent {
+    fun createNotificationService(): NotificationService
+    fun createBlueCommon(): BlueCommon
+    fun createProtocolHandler(): ProtocolHandler
+
     @Component.Factory
     interface Factory {
         fun build(@BindsInstance application: Application): AppComponent

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/AppModule.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/AppModule.kt
@@ -1,0 +1,12 @@
+package io.rebble.fossil.di
+
+import android.app.Application
+import android.content.Context
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class AppModule {
+    @Binds
+    abstract fun bindContext(application: Application): Context
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/AppModule.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/AppModule.kt
@@ -1,6 +1,7 @@
 package io.rebble.fossil.di
 
 import android.app.Application
+import android.bluetooth.BluetoothAdapter
 import android.content.Context
 import dagger.Binds
 import dagger.Module
@@ -9,4 +10,12 @@ import dagger.Module
 abstract class AppModule {
     @Binds
     abstract fun bindContext(application: Application): Context
+
+    @Module
+    companion object {
+        fun provideBluetoothAdapter(): BluetoothAdapter {
+            //TODO what to do when this returns null?
+            return BluetoothAdapter.getDefaultAdapter()
+        }
+    }
 }

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/LibPebbleModule.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/LibPebbleModule.kt
@@ -1,0 +1,31 @@
+package io.rebble.fossil.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.Reusable
+import io.rebble.fossil.BlueCommon
+import io.rebble.libpebblecommon.ProtocolHandler
+import io.rebble.libpebblecommon.services.blobdb.BlobDBService
+import io.rebble.libpebblecommon.services.notification.NotificationService
+import javax.inject.Singleton
+
+@Module
+class LibPebbleModule {
+    @Provides
+    @Singleton
+    fun provideProtocolHandler(
+            blueCommon: BlueCommon
+    ) = ProtocolHandler(blueCommon)
+
+    @Provides
+    @Singleton
+    fun provideBlobDbService(
+            protocolHandler: ProtocolHandler
+    ) = BlobDBService(protocolHandler)
+
+    @Provides
+    @Reusable
+    fun provideNotificationService(
+            blobDBService: BlobDBService
+    ) = NotificationService(blobDBService)
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.0'
 
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,8 @@ allprojects {
                 if (username == null || password == null) throw new GradleScriptException("Set github username and token in local.properties! (GITHUB_ACTOR and GITHUB_TOKEN)", null)
             }
         }
+
+        mavenLocal()
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip

--- a/lib/ui/home/tabs/TestTab.dart
+++ b/lib/ui/home/tabs/TestTab.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:fossil/ui/common/icons/CompIcon.dart';
 import 'package:fossil/ui/common/icons/fonts/RebbleIconsFill.dart';
 import 'package:fossil/ui/common/icons/fonts/RebbleIconsStroke.dart';
 import 'package:fossil/ui/Router.dart';
 
 class TestTab extends StatelessWidget {
+  static const notificationTest = MethodChannel('io.rebble.fossil/notificationTest');
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -15,7 +18,9 @@ class TestTab extends StatelessWidget {
         child: Column(
           children: <Widget>[
             RaisedButton(
-              onPressed: () {},
+              onPressed: () {
+                notificationTest.invokeMethod('sendTestNotification');
+              },
               child: Text("Button"),
             ),
             Text("This is some text."),


### PR DESCRIPTION
This PR adds Dagger and converts most basic flow (sending notifications) to dependency injection. There is still a lot to do, but I feel this is good enough first step to merge it in and continue from there.

Beginning of https://github.com/crc-32/fossil/issues/12

Depends on https://github.com/crc-32/libpebblecommon/pull/1