### PR TITLE
Keep Pebble connected at all times

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,6 +76,7 @@ flutter {
 def libpebblecommon_version = '0.0.6'
 def coroutinesVersion = "1.3.9"
 def lifecycleVersion = "2.2.0"
+def timberVersion = "4.7.1"
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
@@ -87,6 +88,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-service:$lifecycleVersion"
+    implementation "com.jakewharton.timber:timber:$timberVersion"
 
     implementation 'com.google.dagger:dagger:2.29.1'
     kapt 'com.google.dagger:dagger-compiler:2.29.1'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,6 +77,7 @@ def libpebblecommon_version = '0.0.6'
 def coroutinesVersion = "1.3.9"
 def lifecycleVersion = "2.2.0"
 def timberVersion = "4.7.1"
+def androidxCoreVersion = '1.3.2'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
@@ -89,6 +90,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-service:$lifecycleVersion"
     implementation "com.jakewharton.timber:timber:$timberVersion"
+    implementation "androidx.core:core-ktx:$androidxCoreVersion"
 
     implementation 'com.google.dagger:dagger:2.29.1'
     kapt 'com.google.dagger:dagger-compiler:2.29.1'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -80,6 +80,9 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
         </receiver>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
+    <!-- Required to connect to the watch on startup -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <uses-feature android:name="android.software.companion_device_setup" />
 
     <application
@@ -66,11 +69,17 @@
 
         <service android:name=".WatchService" />
         <service
-             android:name=".notifications.NotificationListener"
+            android:name=".notifications.NotificationListener"
             android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
             <intent-filter>
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
+
+        <receiver android:name=".receivers.AppStartReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
+    <uses-feature android:name="android.software.companion_device_setup" />
+
     <application
         android:name=".FossilApplication"
         android:label="fossil"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -90,5 +90,15 @@
                 <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
             </intent-filter>
         </receiver>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="io.rebble.fossil.files"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -84,5 +84,11 @@
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
+
+        <receiver android:name=".receivers.BluetoothAclReceiver">
+            <intent-filter>
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/android/app/src/main/java/io/rebble/fossil/pigeons/Pigeons.java
+++ b/android/app/src/main/java/io/rebble/fossil/pigeons/Pigeons.java
@@ -75,6 +75,60 @@ public class Pigeons {
     /**
      * Generated class from Pigeon that represents data sent in messages.
      */
+    public static class WatchConnectionState {
+        private Boolean isConnected;
+
+        public Boolean getIsConnected() {
+            return isConnected;
+        }
+
+        public void setIsConnected(Boolean setterArg) {
+            this.isConnected = setterArg;
+        }
+
+        private Boolean isConnecting;
+
+        public Boolean getIsConnecting() {
+            return isConnecting;
+        }
+
+        public void setIsConnecting(Boolean setterArg) {
+            this.isConnecting = setterArg;
+        }
+
+        private Long currentWatchAddress;
+
+        public Long getCurrentWatchAddress() {
+            return currentWatchAddress;
+        }
+
+        public void setCurrentWatchAddress(Long setterArg) {
+            this.currentWatchAddress = setterArg;
+        }
+
+        HashMap toMap() {
+            HashMap<String, Object> toMapResult = new HashMap<>();
+            toMapResult.put("isConnected", isConnected);
+            toMapResult.put("isConnecting", isConnecting);
+            toMapResult.put("currentWatchAddress", currentWatchAddress);
+            return toMapResult;
+        }
+
+        static WatchConnectionState fromMap(HashMap map) {
+            WatchConnectionState fromMapResult = new WatchConnectionState();
+            Object isConnected = map.get("isConnected");
+            fromMapResult.isConnected = (Boolean) isConnected;
+            Object isConnecting = map.get("isConnecting");
+            fromMapResult.isConnecting = (Boolean) isConnecting;
+            Object currentWatchAddress = map.get("currentWatchAddress");
+            fromMapResult.currentWatchAddress = (currentWatchAddress == null) ? null : ((currentWatchAddress instanceof Integer) ? (Integer) currentWatchAddress : (Long) currentWatchAddress);
+            return fromMapResult;
+        }
+    }
+
+    /**
+     * Generated class from Pigeon that represents data sent in messages.
+     */
     public static class NumberWrapper {
         private Long value;
 
@@ -250,6 +304,30 @@ public class Pigeons {
                     channel.setMessageHandler(null);
                 }
             }
+        }
+    }
+
+    /**
+     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+     */
+    public static class ConnectionCallbacks {
+        private final BinaryMessenger binaryMessenger;
+
+        public ConnectionCallbacks(BinaryMessenger argBinaryMessenger) {
+            this.binaryMessenger = argBinaryMessenger;
+        }
+
+        public interface Reply<T> {
+            void reply(T reply);
+        }
+
+        public void onWatchConnectionStateChanged(WatchConnectionState argInput, Reply<Void> callback) {
+            BasicMessageChannel<Object> channel =
+                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ConnectionCallbacks.onWatchConnectionStateChanged", new StandardMessageCodec());
+            HashMap inputMap = argInput.toMap();
+            channel.send(inputMap, channelReply -> {
+                callback.reply(null);
+            });
         }
     }
 

--- a/android/app/src/main/java/io/rebble/fossil/pigeons/Pigeons.java
+++ b/android/app/src/main/java/io/rebble/fossil/pigeons/Pigeons.java
@@ -370,6 +370,8 @@ public class Pigeons {
 
         void connectToWatch(NumberWrapper arg);
 
+        void disconnect();
+
         void sendRawPacket(ListWrapper arg);
 
         /**
@@ -404,6 +406,24 @@ public class Pigeons {
                             @SuppressWarnings("ConstantConditions")
                             NumberWrapper input = NumberWrapper.fromMap((HashMap) message);
                             api.connectToWatch(input);
+                            wrapped.put("result", null);
+                        } catch (Exception exception) {
+                            wrapped.put("error", wrapError(exception));
+                        }
+                        reply.reply(wrapped);
+                    });
+                } else {
+                    channel.setMessageHandler(null);
+                }
+            }
+            {
+                BasicMessageChannel<Object> channel =
+                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ConnectionControl.disconnect", new StandardMessageCodec());
+                if (api != null) {
+                    channel.setMessageHandler((message, reply) -> {
+                        HashMap<String, HashMap> wrapped = new HashMap<>();
+                        try {
+                            api.disconnect();
                             wrapped.put("result", null);
                         } catch (Exception exception) {
                             wrapped.put("error", wrapError(exception));

--- a/android/app/src/main/java/io/rebble/fossil/pigeons/Pigeons.java
+++ b/android/app/src/main/java/io/rebble/fossil/pigeons/Pigeons.java
@@ -334,6 +334,37 @@ public class Pigeons {
     /**
      * Generated interface from Pigeon that represents a handler of messages from Flutter.
      */
+    public interface DebugControl {
+        void collectLogs();
+
+        /**
+         * Sets up an instance of `DebugControl` to handle messages through the `binaryMessenger`
+         */
+        static void setup(BinaryMessenger binaryMessenger, DebugControl api) {
+            {
+                BasicMessageChannel<Object> channel =
+                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.DebugControl.collectLogs", new StandardMessageCodec());
+                if (api != null) {
+                    channel.setMessageHandler((message, reply) -> {
+                        HashMap<String, HashMap> wrapped = new HashMap<>();
+                        try {
+                            api.collectLogs();
+                            wrapped.put("result", null);
+                        } catch (Exception exception) {
+                            wrapped.put("error", wrapError(exception));
+                        }
+                        reply.reply(wrapped);
+                    });
+                } else {
+                    channel.setMessageHandler(null);
+                }
+            }
+        }
+    }
+
+    /**
+     * Generated interface from Pigeon that represents a handler of messages from Flutter.
+     */
     public interface ConnectionControl {
         BooleanWrapper isConnected();
 

--- a/android/app/src/main/kotlin/io/rebble/fossil/FossilApplication.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/FossilApplication.kt
@@ -1,5 +1,7 @@
 package io.rebble.fossil
 
+import android.content.Intent
+import androidx.core.content.ContextCompat
 import io.flutter.app.FlutterApplication
 import io.rebble.fossil.di.AppComponent
 import io.rebble.fossil.di.DaggerAppComponent
@@ -12,5 +14,7 @@ class FossilApplication : FlutterApplication() {
         component = DaggerAppComponent.factory().build(this)
 
         super.onCreate()
+
+        ContextCompat.startForegroundService(this, Intent(this, WatchService::class.java))
     }
 }

--- a/android/app/src/main/kotlin/io/rebble/fossil/FossilApplication.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/FossilApplication.kt
@@ -8,6 +8,7 @@ import io.rebble.fossil.di.DaggerAppComponent
 import io.rebble.fossil.log.AppTaggedDebugTree
 import io.rebble.fossil.log.FileLoggingTree
 import timber.log.Timber
+import kotlin.system.exitProcess
 
 class FossilApplication : FlutterApplication() {
     lateinit var component: AppComponent
@@ -18,9 +19,20 @@ class FossilApplication : FlutterApplication() {
 
         super.onCreate()
 
-        Timber.plant(AppTaggedDebugTree("Fossil"))
-        Timber.plant(FileLoggingTree(this, "Fossil"))
+        initLogging()
 
         ContextCompat.startForegroundService(this, Intent(this, WatchService::class.java))
+    }
+
+    private fun initLogging() {
+        Timber.plant(AppTaggedDebugTree("Fossil"))
+        val fileLoggingTree = FileLoggingTree(this, "Fossil")
+        Timber.plant(fileLoggingTree)
+
+        Thread.setDefaultUncaughtExceptionHandler { _, e ->
+            Timber.e(e, "CRASH")
+            fileLoggingTree.waitForLogsToWrite()
+            exitProcess(1)
+        }
     }
 }

--- a/android/app/src/main/kotlin/io/rebble/fossil/FossilApplication.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/FossilApplication.kt
@@ -5,6 +5,9 @@ import androidx.core.content.ContextCompat
 import io.flutter.app.FlutterApplication
 import io.rebble.fossil.di.AppComponent
 import io.rebble.fossil.di.DaggerAppComponent
+import io.rebble.fossil.log.AppTaggedDebugTree
+import io.rebble.fossil.log.FileLoggingTree
+import timber.log.Timber
 
 class FossilApplication : FlutterApplication() {
     lateinit var component: AppComponent
@@ -14,6 +17,9 @@ class FossilApplication : FlutterApplication() {
         component = DaggerAppComponent.factory().build(this)
 
         super.onCreate()
+
+        Timber.plant(AppTaggedDebugTree("Fossil"))
+        Timber.plant(FileLoggingTree(this, "Fossil"))
 
         ContextCompat.startForegroundService(this, Intent(this, WatchService::class.java))
     }

--- a/android/app/src/main/kotlin/io/rebble/fossil/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/MainActivity.kt
@@ -2,8 +2,6 @@ package io.rebble.fossil
 
 import android.Manifest
 import android.app.AlertDialog
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.DialogInterface
@@ -87,19 +85,6 @@ class MainActivity : FlutterActivity() {
         }
     }
 
-    private fun createNotificationChannel() {
-        // Create the NotificationChannel, but only on API 26+ because
-        // the NotificationChannel class is new and not in the support library
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val importance = NotificationManager.IMPORTANCE_DEFAULT
-            val channel = NotificationChannel("device_status", "Device Status", importance)
-            // Register the channel with the system
-            val notificationManager: NotificationManager =
-                    getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.createNotificationChannel(channel)
-        }
-    }
-
     private fun isNotificationServiceEnabled(): Boolean {
         try {
             val pkgName = packageName
@@ -137,8 +122,6 @@ class MainActivity : FlutterActivity() {
         flutterBridges = activityComponent.createFlutterBridges()
 
         handleIntent(intent)
-
-        createNotificationChannel()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (this.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {

--- a/android/app/src/main/kotlin/io/rebble/fossil/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/MainActivity.kt
@@ -12,6 +12,7 @@ import android.os.IBinder
 import android.provider.Settings
 import android.text.TextUtils
 import android.widget.Toast
+import androidx.collection.ArrayMap
 import androidx.core.app.ActivityCompat
 import androidx.lifecycle.lifecycleScope
 import io.flutter.Log
@@ -21,7 +22,6 @@ import io.flutter.plugins.GeneratedPluginRegistrant
 import io.rebble.fossil.bridges.FlutterBridge
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
-import java.lang.NullPointerException
 import java.net.URI
 import kotlin.system.exitProcess
 
@@ -33,6 +33,8 @@ class MainActivity : FlutterActivity() {
     var watchService: WatchService? = null
     var isBound = false
     var bootIntentCallback: ((Boolean) -> Unit)? = null
+
+    val activityResultCallbacks = ArrayMap<Int, (resultCode: Int, data: Intent) -> Unit>()
 
     private val watchServiceConnection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName,
@@ -194,6 +196,12 @@ class MainActivity : FlutterActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleIntent(intent)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        activityResultCallbacks[requestCode]?.invoke(resultCode, data)
     }
 
     public override fun getFlutterEngine(): FlutterEngine? {

--- a/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
@@ -12,10 +12,12 @@ import io.rebble.fossil.bluetooth.ConnectionState
 import io.rebble.libpebblecommon.ProtocolHandler
 import io.rebble.libpebblecommon.services.notification.NotificationService
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class WatchService : LifecycleService() {
     private lateinit var coroutineScope: CoroutineScope
 
@@ -32,7 +34,6 @@ class WatchService : LifecycleService() {
             .setSmallIcon(R.drawable.ic_notification_disconnected)
 
 
-    @ExperimentalStdlibApi
     override fun onCreate() {
         val injectionComponent = (applicationContext as FossilApplication).component
 
@@ -48,6 +49,11 @@ class WatchService : LifecycleService() {
         }
 
         startNotificationLoop()
+
+        if (connectionLooper.connectionState.value is ConnectionState.Disconnected) {
+            injectionComponent.createPairedStorage()
+                    .getMacAddressOfDefaultPebble()?.let { connectionLooper.connectToWatch(it) }
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
@@ -10,7 +10,6 @@ import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
-import io.flutter.Log
 import io.rebble.fossil.bluetooth.ConnectionLooper
 import io.rebble.fossil.bluetooth.ConnectionState
 import io.rebble.libpebblecommon.ProtocolHandler
@@ -20,12 +19,12 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import timber.log.Timber
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WatchService : LifecycleService() {
     private lateinit var coroutineScope: CoroutineScope
 
-    private val logTag: String = "FossilWatchService"
     private val bluetoothAdapter: BluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
 
     private lateinit var protocolHandler: ProtocolHandler
@@ -51,7 +50,7 @@ class WatchService : LifecycleService() {
         createNotificationChannel()
 
         if (!bluetoothAdapter.isEnabled) {
-            Log.w(logTag, "Bluetooth - Not enabled")
+            Timber.w("Bluetooth - Not enabled")
         }
 
         startNotificationLoop()

--- a/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
@@ -1,7 +1,11 @@
 package io.rebble.fossil
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.bluetooth.BluetoothAdapter
+import android.content.Context
 import android.content.Intent
+import android.os.Build
 import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.LifecycleService
@@ -44,6 +48,8 @@ class WatchService : LifecycleService() {
 
         super.onCreate()
 
+        createNotificationChannel()
+
         if (!bluetoothAdapter.isEnabled) {
             Log.w(logTag, "Bluetooth - Not enabled")
         }
@@ -67,26 +73,22 @@ class WatchService : LifecycleService() {
                 @DrawableRes val icon: Int
                 val titleText: String?
                 val deviceName: String?
-                val notificationPriority: Int
 
                 when (it) {
                     is ConnectionState.Disconnected -> {
                         icon = R.drawable.ic_notification_disconnected
                         titleText = "Disconnected"
                         deviceName = null
-                        notificationPriority = NotificationCompat.PRIORITY_LOW
                     }
                     is ConnectionState.Connecting -> {
                         icon = R.drawable.ic_notification_disconnected
                         titleText = "Connecting"
                         deviceName = null
-                        notificationPriority = NotificationCompat.PRIORITY_DEFAULT
                     }
                     is ConnectionState.Connected -> {
                         icon = R.drawable.ic_notification_connected
                         titleText = "Connected to device"
                         deviceName = it.watch.name
-                        notificationPriority = NotificationCompat.PRIORITY_DEFAULT
                     }
                 }
 
@@ -94,10 +96,22 @@ class WatchService : LifecycleService() {
                         .setContentTitle(titleText)
                         .setContentText(deviceName)
                         .setSmallIcon(icon)
-                        .setPriority(notificationPriority)
 
                 startForeground(1, mainNotifBuilder.build())
             }
+        }
+    }
+
+    private fun createNotificationChannel() {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val importance = NotificationManager.IMPORTANCE_MIN
+            val channel = NotificationChannel("device_status", "Device Status", importance)
+            // Register the channel with the system
+            val notificationManager: NotificationManager =
+                    getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
         }
     }
 }

--- a/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
@@ -1,16 +1,9 @@
 package io.rebble.fossil
 
-import android.Manifest
 import android.bluetooth.BluetoothAdapter
 import android.content.Intent
-import android.content.pm.PackageManager
-import android.os.Binder
-import android.os.Build
-import android.os.IBinder
-import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import io.flutter.Log
@@ -23,11 +16,9 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 
-@ExperimentalUnsignedTypes
 class WatchService : LifecycleService() {
     private lateinit var coroutineScope: CoroutineScope
 
-    private val pBinder = ProtBinder()
     private val logTag: String = "FossilWatchService"
     private val bluetoothAdapter: BluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
 
@@ -39,17 +30,6 @@ class WatchService : LifecycleService() {
     private val mainNotifBuilder = NotificationCompat.Builder(this, "device_status")
             .setContentTitle("Disconnected")
             .setSmallIcon(R.drawable.ic_notification_disconnected)
-
-    inner class ProtBinder : Binder() {
-        fun getService(): WatchService {
-            return this@WatchService
-        }
-    }
-
-    override fun onBind(intent: Intent): IBinder {
-        super.onBind(intent)
-        return pBinder
-    }
 
 
     @ExperimentalStdlibApi
@@ -63,15 +43,6 @@ class WatchService : LifecycleService() {
 
         super.onCreate()
 
-        // TODO: BLE
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (this.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                Toast.makeText(this, "Requires location permission for bluetooth LE", Toast.LENGTH_LONG).show()
-                stopSelf()
-                return
-            }
-        }
-
         if (!bluetoothAdapter.isEnabled) {
             Log.w(logTag, "Bluetooth - Not enabled")
         }
@@ -81,7 +52,6 @@ class WatchService : LifecycleService() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
-        startForeground(1, mainNotifBuilder.build())
         return START_STICKY
     }
 
@@ -120,8 +90,7 @@ class WatchService : LifecycleService() {
                         .setSmallIcon(icon)
                         .setPriority(notificationPriority)
 
-                NotificationManagerCompat.from(applicationContext)
-                        .notify(1, mainNotifBuilder.build())
+                startForeground(1, mainNotifBuilder.build())
             }
         }
     }

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BlueCommon.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BlueCommon.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import io.rebble.fossil.bluetooth.classic.BlueSerialDriver
 import io.rebble.fossil.bluetooth.scan.BleScanner
 import io.rebble.fossil.bluetooth.scan.ClassicScanner
+import io.rebble.fossil.util.macAddressToString
 import io.rebble.libpebblecommon.BluetoothConnection
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.flow.Flow
@@ -27,14 +28,7 @@ class BlueCommon @Inject constructor(
     private var externalIncomingPacketHandler: (suspend (ByteArray) -> Unit)? = null
 
     fun startSingleWatchConnection(macAddress: Long): Flow<SingleConnectionStatus> {
-        val hex = "%X".format(macAddress).padStart(12, '0')
-        var btaddr = ""
-        for (i in hex.indices) {
-            btaddr += hex[i]
-            if ((i + 1) % 2 == 0 && i + 1 < hex.length) btaddr += ":"
-        }
-
-        return startSingleWatchConnection(btaddr)
+        return startSingleWatchConnection(macAddress.macAddressToString())
     }
 
     fun startSingleWatchConnection(macAddress: String): Flow<SingleConnectionStatus> {

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BlueCommon.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BlueCommon.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import io.rebble.fossil.bluetooth.classic.BlueSerialDriver
 import io.rebble.fossil.bluetooth.scan.BleScanner
 import io.rebble.fossil.bluetooth.scan.ClassicScanner
-import io.rebble.fossil.util.macAddressToString
 import io.rebble.libpebblecommon.BluetoothConnection
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.flow.Flow
@@ -26,10 +25,6 @@ class BlueCommon @Inject constructor(
     var driver: BlueIO? = null
 
     private var externalIncomingPacketHandler: (suspend (ByteArray) -> Unit)? = null
-
-    fun startSingleWatchConnection(macAddress: Long): Flow<SingleConnectionStatus> {
-        return startSingleWatchConnection(macAddress.macAddressToString())
-    }
 
     fun startSingleWatchConnection(macAddress: String): Flow<SingleConnectionStatus> {
         bleScanner.stopScan()

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BlueCommon.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BlueCommon.kt
@@ -2,13 +2,13 @@ package io.rebble.fossil.bluetooth
 
 import android.bluetooth.BluetoothDevice
 import android.content.Context
-import android.util.Log
 import io.rebble.fossil.bluetooth.classic.BlueSerialDriver
 import io.rebble.fossil.bluetooth.scan.BleScanner
 import io.rebble.fossil.bluetooth.scan.ClassicScanner
 import io.rebble.libpebblecommon.BluetoothConnection
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.flow.Flow
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -19,8 +19,6 @@ class BlueCommon @Inject constructor(
         private val bleScanner: BleScanner,
         private val classicScanner: ClassicScanner
 ) : BluetoothConnection {
-    private val logTag = "BlueCommon"
-
     val bluetoothAdapter = android.bluetooth.BluetoothAdapter.getDefaultAdapter()
     var driver: BlueIO? = null
 
@@ -32,7 +30,7 @@ class BlueCommon @Inject constructor(
 
         val bluetoothDevice = bluetoothAdapter.getRemoteDevice(macAddress)
 
-        Log.d(logTag, "Found Pebble device $bluetoothDevice'")
+        Timber.d("Found Pebble device $bluetoothDevice'")
 
         val driver = getTargetTransport(bluetoothDevice)
         this@BlueCommon.driver = driver

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BlueLEDriver.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BlueLEDriver.kt
@@ -3,16 +3,15 @@ package io.rebble.fossil.bluetooth
 import android.bluetooth.*
 import android.content.Context
 import android.os.Build
-import android.util.Log
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import timber.log.Timber
 import java.util.*
 import kotlin.coroutines.suspendCoroutine
 import kotlin.experimental.or
 
 class BlueLEDriver(private val targetPebble: BluetoothDevice, private val context: Context, private val packetCallback: suspend (ByteArray) -> Unit) : BlueIO {
-    private val logTag = "BlueLE"
     private var connectivityWatcher: ConnectivityWatcher? = null
     private var gattClient: BlueGATTClient? = null
 
@@ -91,17 +90,17 @@ class BlueLEDriver(private val targetPebble: BluetoothDevice, private val contex
             if (status == BluetoothGatt.GATT_SUCCESS) {
                 when (newState) {
                     BluetoothGatt.STATE_CONNECTED -> {
-                        Log.i(logTag, "Pebble connected (initial)")
+                        Timber.i("Pebble connected (initial)")
                         gatt?.discoverServices()
                     }
 
                     BluetoothGatt.STATE_DISCONNECTED -> {
-                        Log.i(logTag, "Pebble disconnected")
+                        Timber.i("Pebble disconnected")
                         connectionState = LEConnectionState.IDLE
                     }
                 }
             } else {
-                Log.e(logTag, "Connection error: ${resolveGattError(status)}")
+                Timber.e("Connection error: ${resolveGattError(status)}")
             }
         }
 
@@ -144,35 +143,35 @@ class BlueLEDriver(private val targetPebble: BluetoothDevice, private val contex
         gatt = targetPebble.connectGatt(context, false, gattCallbacks)
 
         if (gatt == null) {
-            Log.e(logTag, "connectGatt failed")
+            Timber.e("connectGatt failed")
             return@flow
         } else {
             connectivityWatcher = ConnectivityWatcher(gatt!!) {
                 if (!it.paired || targetPebble.bondState == BluetoothDevice.BOND_NONE) {
                     if (connectionState == LEConnectionState.PAIRING) {
                         if (it.pairingErrorCode == ConnectivityWatcher.PairingErrorCode.CONFIRM_VALUE_FAILED) {
-                            Log.e(logTag, "Failed to pair")
+                            Timber.e("Failed to pair")
                             closePebble()
                         }
                     } else if (connectionState != LEConnectionState.CONNECTED) {
                         connectionState = LEConnectionState.PAIRING
                         val pairService = gatt?.getService(BlueGATTConstants.UUIDs.PAIRING_SERVICE_UUID)
                         if (pairService == null) {
-                            Log.e(logTag, "pairService is null")
+                            Timber.e("pairService is null")
                         } else {
                             val pairTrigger = pairService.getCharacteristic(BlueGATTConstants.UUIDs.PAIRING_TRIGGER_CHARACTERISTIC)
                             if (pairTrigger == null) {
-                                Log.e(logTag, "pairTrigger is null")
+                                Timber.e("pairTrigger is null")
                             } else {
                                 if (pairTrigger.properties and BluetoothGattCharacteristic.PROPERTY_WRITE > 0) {
                                     pairTrigger.setValue(pairTriggerFlagsToBytes(it.supportsPinningWithoutSlaveSecurity, Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP, false))
                                     if (!gatt!!.writeCharacteristic(pairTrigger)) {
-                                        Log.e(logTag, "Failed to write to pair characteristic")
+                                        Timber.e("Failed to write to pair characteristic")
                                         closePebble()
                                     }
                                 }
                                 if (!gatt?.device?.createBond()!!) {
-                                    Log.e(logTag, "Failed to create bond")
+                                    Timber.e("Failed to create bond")
                                     closePebble()
                                 } else {
                                     connectionState = LEConnectionState.CONNECTING_GATT

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BluePebbleDevice.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/BluePebbleDevice.kt
@@ -5,6 +5,7 @@ import android.bluetooth.le.ScanResult
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.collection.ArrayMap
+import io.rebble.fossil.util.macAddressToLong
 
 @OptIn(ExperimentalUnsignedTypes::class)
 class BluePebbleDevice {
@@ -31,7 +32,7 @@ class BluePebbleDevice {
         val map = ArrayMap<String, Any>()
 
         map["name"] = bluetoothDevice.name
-        map["address"] = bluetoothDevice.address.replace(":", "").toLong(16)
+        map["address"] = bluetoothDevice.address.macAddressToLong()
 
         if (leMeta?.major != null) {
             map["version"] = "${leMeta.major}.${leMeta.minor}.${leMeta.patch}"

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectionLooper.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectionLooper.kt
@@ -1,10 +1,10 @@
 package io.rebble.fossil.bluetooth
 
-import android.util.Log
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -39,7 +39,7 @@ class ConnectionLooper @Inject constructor(
                             }
                         }
                     } catch (e: Exception) {
-                        Log.e(TAG, "Watch connection error", e)
+                        Timber.e(e, "Watch connection error")
                     }
 
 
@@ -48,11 +48,11 @@ class ConnectionLooper @Inject constructor(
 
                     retryTime *= 2
                     if (retryTime > MAX_RETRY_TIME) {
-                        Log.d(TAG, "Watch failed to connect after numerous attempts. Abort connection.")
+                        Timber.d("Watch failed to connect after numerous attempts. Abort connection.")
 
                         break
                     }
-                    Log.d(TAG, "Watch connection failed, waiting and reconnecting after $retryTime ms")
+                    Timber.d("Watch connection failed, waiting and reconnecting after $retryTime ms")
                     delay(retryTime)
                 }
             } finally {
@@ -75,4 +75,3 @@ private fun SingleConnectionStatus.toConnectionStatus(): ConnectionState {
 
 private const val HALF_OF_INITAL_RETRY_TIME = 2_000L // initial retry = 4 seconds
 private const val MAX_RETRY_TIME = 10 * 3600 * 1000L // 10 hours
-private const val TAG = "ConnectionLooper"

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectionLooper.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectionLooper.kt
@@ -23,7 +23,7 @@ class ConnectionLooper @Inject constructor(
 
     private var currentConnection: Job? = null
 
-    fun connectToWatch(macAddress: Long) {
+    fun connectToWatch(macAddress: String) {
         coroutineScope.launch {
             try {
                 currentConnection?.cancelAndJoin()

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectionLooper.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectionLooper.kt
@@ -40,6 +40,8 @@ class ConnectionLooper @Inject constructor(
 
                     // TODO exponential backoff
                     Log.d(TAG, "Watch connection failed, waiting and reconnecting")
+                    val lastWatch = connectionState.value.watchOrNull
+                    _connectionState.value = ConnectionState.Connecting(lastWatch)
                     delay(5000)
                 }
             } finally {

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectionState.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectionState.kt
@@ -4,6 +4,15 @@ import android.bluetooth.BluetoothDevice
 
 sealed class ConnectionState {
     object Disconnected : ConnectionState()
-    class Connecting(val watch: BluetoothDevice) : ConnectionState()
+    class Connecting(val watch: BluetoothDevice?) : ConnectionState()
     class Connected(val watch: BluetoothDevice) : ConnectionState()
 }
+
+val ConnectionState.watchOrNull: BluetoothDevice?
+    get() {
+        return when (this) {
+            is ConnectionState.Connecting -> watch
+            is ConnectionState.Connected -> watch
+            ConnectionState.Disconnected -> null
+        }
+    }

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectivityWatcher.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/ConnectivityWatcher.kt
@@ -3,13 +3,11 @@ package io.rebble.fossil.bluetooth
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
-import android.util.Log
-import io.rebble.fossil.util.toHexString
+import timber.log.Timber
 import kotlin.experimental.and
 import kotlin.properties.Delegates
 
 class ConnectivityWatcher(val gatt: BluetoothGatt, val onConnectivityChanged: (ConnectivityStatus) -> Unit) {
-    private val logTag = "ConnectivityWatcher"
     private var isSubscribed = false
     var lastStatus: ConnectivityStatus? = null
 
@@ -64,26 +62,26 @@ class ConnectivityWatcher(val gatt: BluetoothGatt, val onConnectivityChanged: (C
     fun subscribe(): Boolean {
         val pairService = gatt.getService(BlueGATTConstants.UUIDs.PAIRING_SERVICE_UUID)
         if (pairService == null) {
-            Log.e(logTag, "pairService is null")
+            Timber.e("pairService is null")
             return false
         } else {
             val connectivityCharacteristic = pairService.getCharacteristic(BlueGATTConstants.UUIDs.CONNECTIVITY_CHARACTERISTIC)
             if (connectivityCharacteristic == null) {
-                Log.e(logTag, "connectivityCharacteristic is null")
+                Timber.e("connectivityCharacteristic is null")
             } else {
                 val configDescriptor = connectivityCharacteristic.getDescriptor(BlueGATTConstants.UUIDs.CHARACTERISTIC_CONFIGURATION_DESCRIPTOR)
                 if (configDescriptor == null) {
-                    Log.e(logTag, "configDescriptor for connectivityCharacteristic is null")
+                    Timber.e("configDescriptor for connectivityCharacteristic is null")
                     return false
                 } else {
                     configDescriptor.setValue(BlueGATTConstants.CHARACTERISTIC_SUBSCRIBE_VALUE)
                     if (!gatt.writeDescriptor(configDescriptor)) {
-                        Log.e(logTag, "Failed to write subscribe value to connectivityCharacteristic's configDescriptor")
+                        Timber.e("Failed to write subscribe value to connectivityCharacteristic's configDescriptor")
                         return false
                     } else {
-                        Log.d(logTag, "Requesting subscribe to connectivity characteristic")
+                        Timber.d("Requesting subscribe to connectivity characteristic")
                         if (!gatt.setCharacteristicNotification(connectivityCharacteristic, true)) {
-                            Log.e(logTag, "BluetoothGatt refused to subscribe to connectivity characteristic")
+                            Timber.e("BluetoothGatt refused to subscribe to connectivity characteristic")
                             return false
                         }
                     }
@@ -96,17 +94,17 @@ class ConnectivityWatcher(val gatt: BluetoothGatt, val onConnectivityChanged: (C
     fun onDescriptorWrite(gatt: BluetoothGatt?, descriptor: BluetoothGattDescriptor?, status: Int) {
         if (descriptor?.characteristic?.uuid == BlueGATTConstants.UUIDs.CONNECTIVITY_CHARACTERISTIC && descriptor?.uuid == BlueGATTConstants.UUIDs.CHARACTERISTIC_CONFIGURATION_DESCRIPTOR) {
             if (status == BluetoothGatt.GATT_SUCCESS) {
-                Log.d(logTag, "Subscribed to connectivity characteristic")
+                Timber.d("Subscribed to connectivity characteristic")
                 isSubscribed = true
                 val currentConnectivity = descriptor?.characteristic?.value
                 if (currentConnectivity == null) {
-                    Log.d(logTag, "Connectivity descriptor value null")
+                    Timber.d("Connectivity descriptor value null")
                 } else {
                     lastStatus = ConnectivityStatus(currentConnectivity)
                     onConnectivityChanged(lastStatus!!)
                 }
             } else {
-                Log.e(logTag, "Subscribe to connectivity characteristic failed")
+                Timber.e("Subscribe to connectivity characteristic failed")
                 isSubscribed = false
             }
         }

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/LEMeta.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/LEMeta.kt
@@ -1,7 +1,6 @@
 package io.rebble.fossil.bluetooth
 
-import android.util.Log
-import io.rebble.fossil.util.toHexString
+import timber.log.Timber
 import java.nio.BufferUnderflowException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -40,7 +39,7 @@ data class LEMeta(private val scanRecord: ByteArray) {
             }
         }
         if (!seekComplete) {
-            Log.e("LEMeta", "No manufacturer specific data in GAP")
+            Timber.e("No manufacturer specific data in GAP")
             vendor = -1
             payloadType = 0
             serialNumber = "??"
@@ -62,7 +61,7 @@ data class LEMeta(private val scanRecord: ByteArray) {
                 recordRaw.get(serialChars)
                 serialNumber = String(serialChars)
             } else {
-                Log.e("LEMeta", "Mandatory manufacturer specific data malformed")
+                Timber.e("Mandatory manufacturer specific data malformed")
                 vendor = -1
                 payloadType = 0
                 serialNumber = "??"
@@ -74,7 +73,7 @@ data class LEMeta(private val scanRecord: ByteArray) {
             try {
                 _hardwarePlatform = recordRaw.get().toUByte()
             } catch (e: BufferUnderflowException) {
-                Log.w("LEMeta", "Extra manufacturer specific data not present")
+                Timber.w("Extra manufacturer specific data not present")
                 hasExtras = false
             }
 

--- a/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/classic/BlueSerialDriver.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bluetooth/classic/BlueSerialDriver.kt
@@ -2,7 +2,6 @@ package io.rebble.fossil.bluetooth.classic
 
 import android.bluetooth.BluetoothDevice
 import android.content.Context
-import io.flutter.Log
 import io.rebble.fossil.bluetooth.BlueIO
 import io.rebble.fossil.bluetooth.SingleConnectionStatus
 import kotlinx.coroutines.Dispatchers
@@ -10,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
@@ -23,7 +23,6 @@ class BlueSerialDriver(
         private val context: Context,
         private val packetCallback: suspend (ByteArray) -> Unit
 ) : BlueIO {
-    private val logTag = "BlueSerial"
     private var outputStream: OutputStream? = null
 
     override fun startSingleWatchConnection(device: BluetoothDevice): Flow<SingleConnectionStatus> = flow {
@@ -52,14 +51,14 @@ class BlueSerialDriver(
                 val length = metBuf.short
                 val endpoint = metBuf.short
                 if (length < 0 || length > buf.capacity()) {
-                    Log.w(logTag, "Invalid length in packet (EP $endpoint): got $length")
+                    Timber.w("Invalid length in packet (EP $endpoint): got $length")
                     continue
                 }
 
                 /* READ PACKET CONTENT */
                 inputStream.readFully(buf, 4, length.toInt())
 
-                Log.d(logTag, "Got packet: EP $endpoint | Length $length")
+                Timber.d("Got packet: EP $endpoint | Length $length")
 
                 buf.rewind()
                 val packet = ByteArray(length.toInt() + 2 * (Short.SIZE_BYTES))

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/AppLifecycle.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/AppLifecycle.kt
@@ -1,5 +1,8 @@
 package io.rebble.fossil.bridges
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
 import io.flutter.plugin.common.BasicMessageChannel
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.StandardMessageCodec
@@ -15,7 +18,8 @@ import javax.inject.Inject
 class AppLifecycle @Inject constructor(
         binaryMessenger: BinaryMessenger,
         mainActivity: MainActivity,
-        coroutineScope: CoroutineScope
+        coroutineScope: CoroutineScope,
+        lifecycle: Lifecycle
 ) : FlutterBridge {
     private val bootTrigger = CompletableDeferred<Boolean>()
 
@@ -41,5 +45,13 @@ class AppLifecycle @Inject constructor(
             wrapped["result"] = output.toMapExt()
             wrapped
         }
+
+        lifecycle.addObserver(object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                if (event == Lifecycle.Event.ON_DESTROY) {
+                    channel.setMessageHandler(null)
+                }
+            }
+        })
     }
 }

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/BridgeLifecycleController.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/BridgeLifecycleController.kt
@@ -28,7 +28,6 @@ class BridgeLifecycleController @Inject constructor(
     }
 
     init {
-        println("Init controller")
         lifecycle.addObserver(object : LifecycleEventObserver {
             override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
                 if (event == Lifecycle.Event.ON_DESTROY) {

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/BridgeLifecycleController.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/BridgeLifecycleController.kt
@@ -1,0 +1,42 @@
+package io.rebble.fossil.bridges
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import io.flutter.plugin.common.BinaryMessenger
+import io.rebble.fossil.di.PerActivity
+import javax.inject.Inject
+
+@PerActivity
+/**
+ * Helper that automatically closes down all pigeon bridges when activity is destroyed
+ */
+class BridgeLifecycleController @Inject constructor(
+        private val binaryMessenger: BinaryMessenger,
+        lifecycle: Lifecycle
+) {
+    private val activatedSetupMethods = ArrayList<(BinaryMessenger, Any?) -> Unit>()
+
+    fun <T> setupControl(pigeonSetupMethod: (BinaryMessenger, T) -> Unit, callback: T) {
+        pigeonSetupMethod(binaryMessenger, callback)
+        @Suppress("UNCHECKED_CAST")
+        activatedSetupMethods.add(pigeonSetupMethod as (BinaryMessenger, Any?) -> Unit)
+    }
+
+    fun <T> createCallbacks(pigeonSetupMethod: (BinaryMessenger) -> T): T {
+        return pigeonSetupMethod(binaryMessenger)
+    }
+
+    init {
+        println("Init controller")
+        lifecycle.addObserver(object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                if (event == Lifecycle.Event.ON_DESTROY) {
+                    for (setupMethod in activatedSetupMethods) {
+                        setupMethod.invoke(binaryMessenger, null)
+                    }
+                }
+            }
+        })
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
@@ -1,10 +1,27 @@
 package io.rebble.fossil.bridges
 
+import android.annotation.TargetApi
+import android.app.Activity
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.companion.AssociationRequest
+import android.companion.BluetoothDeviceFilter
+import android.companion.BluetoothLeDeviceFilter
+import android.companion.CompanionDeviceManager
+import android.content.Context
+import android.content.Intent
+import android.content.IntentSender
+import android.os.Build
+import io.flutter.Log
+import io.rebble.fossil.MainActivity
 import io.rebble.fossil.bluetooth.BlueCommon
 import io.rebble.fossil.bluetooth.ConnectionLooper
 import io.rebble.fossil.bluetooth.ConnectionState
 import io.rebble.fossil.pigeons.BooleanWrapper
 import io.rebble.fossil.pigeons.Pigeons
+import io.rebble.fossil.util.macAddressToString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -15,10 +32,17 @@ class Connection @Inject constructor(
         bridgeLifecycleController: BridgeLifecycleController,
         private val connectionLooper: ConnectionLooper,
         private val blueCommon: BlueCommon,
-        private val coroutineScope: CoroutineScope
+        private val coroutineScope: CoroutineScope,
+        private val activity: MainActivity
 ) : FlutterBridge, Pigeons.ConnectionControl {
     init {
         bridgeLifecycleController.setupControl(Pigeons.ConnectionControl::setup, this)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            activity.activityResultCallbacks[REQUEST_CODE_COMPANION_DEVICE_MANAGER] =
+                    this::processCompanionDeviceResult
+        }
+
     }
 
     override fun isConnected(): Pigeons.BooleanWrapper {
@@ -26,9 +50,91 @@ class Connection @Inject constructor(
     }
 
     override fun connectToWatch(arg: Pigeons.NumberWrapper) {
-        val address = arg.value
+        try {
+            val address = arg.value.macAddressToString()
 
-        connectionLooper.connectToWatch(address)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                associateWithCompanionDeviceManager(address)
+            } else {
+                openConnectionToWatch(address)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    private fun associateWithCompanionDeviceManager(macAddress: String) {
+        val companionDeviceManager =
+                activity.getSystemService(Context.COMPANION_DEVICE_SERVICE) as CompanionDeviceManager
+
+        val existingBoundDevices = companionDeviceManager.associations
+        if (existingBoundDevices.contains(macAddress)) {
+            openConnectionToWatch(macAddress)
+            return
+        }
+
+        val deviceType = BluetoothAdapter.getDefaultAdapter().getRemoteDevice(macAddress).type
+        val filter = if (deviceType == BluetoothDevice.DEVICE_TYPE_LE) {
+            BluetoothLeDeviceFilter.Builder()
+                    .setScanFilter(ScanFilter.Builder().setDeviceAddress(macAddress).build())
+                    .build()
+        } else {
+            BluetoothDeviceFilter.Builder()
+                    .setAddress(macAddress)
+                    .build()
+        }
+
+
+        val associationRequest = AssociationRequest.Builder()
+                .addDeviceFilter(filter)
+                .setSingleDevice(true)
+                .build()
+
+        companionDeviceManager.associate(associationRequest, object : CompanionDeviceManager.Callback() {
+            override fun onDeviceFound(chooserLauncher: IntentSender) {
+                activity.startIntentSenderForResult(
+                        chooserLauncher,
+                        REQUEST_CODE_COMPANION_DEVICE_MANAGER,
+                        null,
+                        0,
+                        0,
+                        0
+                )
+            }
+
+            override fun onFailure(error: CharSequence?) {
+                Log.e("Connection", "Device association failure")
+            }
+        }, null)
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    private fun processCompanionDeviceResult(resultCode: Int, data: Intent) {
+        if (resultCode != Activity.RESULT_OK) {
+            return
+        }
+
+        val deviceToPair: Any =
+                data.getParcelableExtra(CompanionDeviceManager.EXTRA_DEVICE)!!
+
+        val address = when (deviceToPair) {
+            is BluetoothDevice -> {
+                deviceToPair.address
+            }
+            is ScanResult -> {
+                deviceToPair.device.address
+            }
+            else -> {
+                throw IllegalStateException("Unknown device type: $deviceToPair")
+            }
+        }
+
+        openConnectionToWatch(address)
+    }
+
+    private fun openConnectionToWatch(macAddress: String) {
+        connectionLooper.connectToWatch(macAddress)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -39,3 +145,5 @@ class Connection @Inject constructor(
         }
     }
 }
+
+private const val REQUEST_CODE_COMPANION_DEVICE_MANAGER = 1557

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
@@ -14,7 +14,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentSender
 import android.os.Build
-import io.flutter.Log
 import io.rebble.fossil.MainActivity
 import io.rebble.fossil.bluetooth.BlueCommon
 import io.rebble.fossil.bluetooth.ConnectionLooper
@@ -29,6 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -122,7 +122,7 @@ class Connection @Inject constructor(
             }
 
             override fun onFailure(error: CharSequence?) {
-                Log.e("Connection", "Device association failure")
+                Timber.e("Device association failure")
             }
         }, null)
     }

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
@@ -134,6 +134,7 @@ class Connection @Inject constructor(
     }
 
     private fun openConnectionToWatch(macAddress: String) {
+        println("Open watch $macAddress")
         connectionLooper.connectToWatch(macAddress)
     }
 

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
@@ -81,6 +81,10 @@ class Connection @Inject constructor(
         }
     }
 
+    override fun disconnect() {
+        connectionLooper.closeConnection()
+    }
+
     @TargetApi(Build.VERSION_CODES.O)
     private fun associateWithCompanionDeviceManager(macAddress: String) {
         val companionDeviceManager =

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/Connection.kt
@@ -1,6 +1,5 @@
 package io.rebble.fossil.bridges
 
-import io.flutter.plugin.common.BinaryMessenger
 import io.rebble.fossil.bluetooth.BlueCommon
 import io.rebble.fossil.bluetooth.ConnectionLooper
 import io.rebble.fossil.bluetooth.ConnectionState
@@ -13,13 +12,13 @@ import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class Connection @Inject constructor(
-        binaryMessenger: BinaryMessenger,
+        bridgeLifecycleController: BridgeLifecycleController,
         private val connectionLooper: ConnectionLooper,
         private val blueCommon: BlueCommon,
         private val coroutineScope: CoroutineScope
 ) : FlutterBridge, Pigeons.ConnectionControl {
     init {
-        Pigeons.ConnectionControl.setup(binaryMessenger, this)
+        bridgeLifecycleController.setupControl(Pigeons.ConnectionControl::setup, this)
     }
 
     override fun isConnected(): Pigeons.BooleanWrapper {

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/Debug.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/Debug.kt
@@ -1,0 +1,19 @@
+package io.rebble.fossil.bridges
+
+import android.content.Context
+import io.rebble.fossil.log.collectAndShareLogs
+import io.rebble.fossil.pigeons.Pigeons
+import javax.inject.Inject
+
+class Debug @Inject constructor(
+        private val context: Context,
+        bridgeLifecycleController: BridgeLifecycleController
+) : FlutterBridge, Pigeons.DebugControl {
+    init {
+        bridgeLifecycleController.setupControl(Pigeons.DebugControl::setup, this)
+    }
+
+    override fun collectLogs() {
+        collectAndShareLogs(context)
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/Notifications.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/Notifications.kt
@@ -1,6 +1,5 @@
 package io.rebble.fossil.bridges
 
-import io.flutter.plugin.common.BinaryMessenger
 import io.rebble.fossil.pigeons.Pigeons
 import io.rebble.libpebblecommon.blobdb.PushNotification
 import io.rebble.libpebblecommon.services.notification.NotificationService
@@ -9,12 +8,12 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class Notifications @Inject constructor(
-        binaryMessenger: BinaryMessenger,
+        bridgeLifecycleController: BridgeLifecycleController,
         private val notificationService: NotificationService,
         private val coroutineScope: CoroutineScope
 ) : FlutterBridge, Pigeons.NotificationsControl {
     init {
-        Pigeons.NotificationsControl.setup(binaryMessenger, this)
+        bridgeLifecycleController.setupControl(Pigeons.NotificationsControl::setup, this)
     }
 
     override fun sendTestNotification() {

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/Scan.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/Scan.kt
@@ -1,6 +1,5 @@
 package io.rebble.fossil.bridges
 
-import io.flutter.plugin.common.BinaryMessenger
 import io.rebble.fossil.bluetooth.scan.BleScanner
 import io.rebble.fossil.bluetooth.scan.ClassicScanner
 import io.rebble.fossil.pigeons.ListWrapper
@@ -12,15 +11,16 @@ import javax.inject.Inject
 
 @OptIn(ExperimentalUnsignedTypes::class)
 class Scan @Inject constructor(
-        binaryMessenger: BinaryMessenger,
+        bridgeLifecycleController: BridgeLifecycleController,
         private val bleScanner: BleScanner,
         private val classicScanner: ClassicScanner,
         private val coroutineScope: CoroutineScope
 ) : FlutterBridge, Pigeons.ScanControl {
-    private val scanCallbacks = Pigeons.ScanCallbacks(binaryMessenger)
+    private val scanCallbacks =
+            bridgeLifecycleController.createCallbacks(Pigeons::ScanCallbacks)
 
     init {
-        Pigeons.ScanControl.setup(binaryMessenger, this)
+        bridgeLifecycleController.setupControl(Pigeons.ScanControl::setup, this)
     }
 
     override fun startBleScan() {

--- a/android/app/src/main/kotlin/io/rebble/fossil/datasources/PairedStorage.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/datasources/PairedStorage.kt
@@ -1,0 +1,39 @@
+package io.rebble.fossil.datasources
+
+import android.content.Context
+import android.util.Base64
+import io.rebble.fossil.util.macAddressToString
+import org.json.JSONObject
+import java.io.ByteArrayInputStream
+import java.io.ObjectInputStream
+import javax.inject.Inject
+
+class PairedStorage @Inject constructor(private val context: Context) {
+    fun getMacAddressOfDefaultPebble(): String? {
+        val preferences = context.getSharedPreferences(
+                "FlutterSharedPreferences",
+                Context.MODE_PRIVATE
+        )
+
+        // Read flutter's shared preferences
+        // Reference: https://github.com/flutter/plugins/blob/c696333a93d00eb2be2593ca2bcfee235bfc8936/packages/shared_preferences/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/MethodCallHandlerImpl.java
+
+        val pairListRaw = preferences.getString("flutter.pairList", null)
+                ?: return null
+
+        val pairListBase64 = pairListRaw.removePrefix("VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIGxpc3Qu")
+
+        val bytes = Base64.decode(pairListBase64, 0)
+
+        @Suppress("UNCHECKED_CAST")
+        val deviceJsons = ObjectInputStream(ByteArrayInputStream(bytes)).use {
+            it.readObject()
+        } as List<String>
+
+        val devices = deviceJsons.map { JSONObject(it) }
+
+        return devices.first {
+            it.getBoolean("isDefault")
+        }.getJSONObject("device").getLong("address").macAddressToString()
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/ActivityModule.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/ActivityModule.kt
@@ -1,5 +1,6 @@
 package io.rebble.fossil.di
 
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.Module
 import dagger.Provides
@@ -10,6 +11,11 @@ import kotlinx.coroutines.CoroutineScope
 
 @Module
 class ActivityModule {
+    @Provides
+    fun provideLifecycle(mainActivity: MainActivity): Lifecycle {
+        return mainActivity.lifecycle
+    }
+
     @Provides
     fun provideCoroutineScope(mainActivity: MainActivity): CoroutineScope {
         return mainActivity.lifecycleScope

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/ActivitySubcomponent.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/ActivitySubcomponent.kt
@@ -4,7 +4,9 @@ import dagger.BindsInstance
 import dagger.Subcomponent
 import io.rebble.fossil.MainActivity
 import io.rebble.fossil.bridges.FlutterBridge
+import javax.inject.Scope
 
+@PerActivity
 @Subcomponent(
         modules = [
             ActivityModule::class,
@@ -19,3 +21,6 @@ interface ActivitySubcomponent {
         fun create(@BindsInstance mainActivity: MainActivity): ActivitySubcomponent
     }
 }
+
+@Scope
+annotation class PerActivity

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/AppComponent.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/AppComponent.kt
@@ -5,6 +5,7 @@ import dagger.BindsInstance
 import dagger.Component
 import io.rebble.fossil.bluetooth.BlueCommon
 import io.rebble.fossil.bluetooth.ConnectionLooper
+import io.rebble.fossil.datasources.PairedStorage
 import io.rebble.fossil.errors.GlobalExceptionHandler
 import io.rebble.libpebblecommon.ProtocolHandler
 import io.rebble.libpebblecommon.services.notification.NotificationService
@@ -21,6 +22,7 @@ interface AppComponent {
     fun createProtocolHandler(): ProtocolHandler
     fun createExceptionHandler(): GlobalExceptionHandler
     fun createConnectionLooper(): ConnectionLooper
+    fun createPairedStorage(): PairedStorage
 
     fun createActivitySubcomponentFactory(): ActivitySubcomponent.Factory
 

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/FlutterBridgesModule.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/FlutterBridgesModule.kt
@@ -22,4 +22,8 @@ abstract class FlutterBridgesModule {
     @Binds
     @IntoSet
     abstract fun bindAppLifecycleBridge(appLifecycle: AppLifecycle): FlutterBridge
+
+    @Binds
+    @IntoSet
+    abstract fun bindDebugBridge(debug: Debug): FlutterBridge
 }

--- a/android/app/src/main/kotlin/io/rebble/fossil/errors/GlobalErrorHandler.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/errors/GlobalErrorHandler.kt
@@ -1,7 +1,7 @@
 package io.rebble.fossil.errors
 
-import android.util.Log
 import kotlinx.coroutines.CoroutineExceptionHandler
+import timber.log.Timber
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
@@ -11,7 +11,7 @@ import kotlin.coroutines.CoroutineContext
 class GlobalExceptionHandler @Inject constructor() : CoroutineExceptionHandler {
     override fun handleException(context: CoroutineContext, exception: Throwable) {
         // TODO properly handle exceptions (logging?)
-        Log.e("Fossil", "Coroutine exception", exception)
+        Timber.e(exception, "Coroutine exception")
     }
 
     override val key: CoroutineContext.Key<*>

--- a/android/app/src/main/kotlin/io/rebble/fossil/log/AppTaggedDebugTree.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/log/AppTaggedDebugTree.kt
@@ -1,0 +1,15 @@
+package io.rebble.fossil.log
+
+import timber.log.Timber
+
+/**
+ * A [timber.log.Timber.Tree] that sets tag to app name and includes actual tag in the message.
+ * This is useful for viewing logs on the phone as most logcat apps do not support per-app filtering.
+ *
+ * Taken from https://github.com/matejdro/WearUtils/blob/011964110a541126e3639172dc81b72ccf836a27/src/main/java/timber/log/Timber.java
+ */
+open class AppTaggedDebugTree(private val appTag: String) : Timber.DebugTree() {
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        super.log(priority, appTag, "[$tag] $message", t)
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/log/FileLoggingTree.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/log/FileLoggingTree.kt
@@ -3,9 +3,7 @@ package io.rebble.fossil.log
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import java.io.*
 import java.text.DateFormat
 import java.text.SimpleDateFormat
@@ -75,6 +73,15 @@ class FileLoggingTree(context: Context, appTag: String) : AppTaggedDebugTree(app
             writer = BufferedWriter(FileWriter(file, true))
         } catch (ignored: IOException) {
             writer = null
+        }
+    }
+
+    fun waitForLogsToWrite() {
+        runBlocking {
+            withContext(loggingDispatcher) {
+                writer?.close()
+                writer = null
+            }
         }
     }
 

--- a/android/app/src/main/kotlin/io/rebble/fossil/log/FileLoggingTree.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/log/FileLoggingTree.kt
@@ -1,0 +1,99 @@
+package io.rebble.fossil.log
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import java.io.*
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.*
+import java.util.concurrent.Executors
+
+class FileLoggingTree(context: Context, appTag: String) : AppTaggedDebugTree(appTag) {
+    private val loggingDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+
+    val logsFolder = File(context.cacheDir, "logs")
+
+    private var writer: BufferedWriter? = null
+    private val currentDayOfYear: Int = -1
+
+    @Suppress("BlockingMethodInNonBlockingContext")
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        GlobalScope.launch(loggingDispatcher) {
+            Thread.currentThread().priority = Thread.MIN_PRIORITY
+
+            openFileIfNeeded()
+            val writer = writer ?: return@launch
+
+            try {
+                val calendar = Calendar.getInstance()
+                writer.write(
+                        getLogPriorityAbbreviation(priority).toString() + " " +
+                                LOG_DATE_FORMAT.format(calendar.time) + " [" +
+                                tag + "Z] " +
+                                message
+                )
+                writer.newLine()
+
+                t?.printStackTrace(PrintWriter(writer))
+
+                writer.flush()
+            } catch (ignored: IOException) {
+                try {
+                    writer.close()
+                } catch (ignored2: IOException) {
+                }
+                this@FileLoggingTree.writer = null
+            }
+        }
+
+    }
+
+    private fun openFileIfNeeded() {
+        val today = Calendar.getInstance()
+        if (writer != null && today.get(Calendar.DAY_OF_YEAR) == currentDayOfYear) {
+            // Latest file is already open. No need to do anything.
+            return
+        }
+
+        if (!logsFolder.exists()) {
+            if (!logsFolder.mkdir()) {
+                throw RuntimeException("Cannot create logging folder!")
+            }
+        }
+
+        val fileNameTimeStamp = SimpleDateFormat("yyyy-dd-MM", Locale.getDefault())
+                .format(Date())
+
+        val filename = "log_$fileNameTimeStamp.log"
+        val file = File(logsFolder, filename)
+
+        try {
+            writer = BufferedWriter(FileWriter(file, true))
+        } catch (ignored: IOException) {
+            writer = null
+        }
+    }
+
+
+    private fun getLogPriorityAbbreviation(priority: Int): Char {
+        return when (priority) {
+            Log.ASSERT -> 'A'
+            Log.DEBUG -> 'D'
+            Log.ERROR -> 'E'
+            Log.INFO -> 'I'
+            Log.WARN -> 'W'
+            else -> 'V'
+        }
+    }
+}
+
+@SuppressLint("ConstantLocale")
+private val LOG_DATE_FORMAT: DateFormat = SimpleDateFormat(
+        "HH:mm:ss.SSS", Locale.getDefault()
+).apply {
+    timeZone = TimeZone.getTimeZone("UTC")
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/log/LogSendingTask.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/log/LogSendingTask.kt
@@ -1,0 +1,77 @@
+package io.rebble.fossil.log
+
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+
+/**
+ * This should be eventually moved to flutter. Written it in Kotlin for now so we can use it while
+ * testing other things.
+ */
+fun collectAndShareLogs(context: Context) = GlobalScope.launch(Dispatchers.IO) {
+    val logsFolder = File(context.cacheDir, "logs")
+
+    val targetFile = File(logsFolder, "logs.zip")
+
+    var zipOutputStream: ZipOutputStream? = null
+    try {
+        zipOutputStream = ZipOutputStream(FileOutputStream(targetFile))
+        for (file in logsFolder.listFiles() ?: emptyArray()) {
+            if (!file.name.endsWith(".log")) {
+                continue
+            }
+            val zipEntry = ZipEntry(file.name)
+            zipOutputStream.putNextEntry(zipEntry)
+            val buffer = ByteArray(1024)
+            val inputStream = FileInputStream(file)
+            var readBytes: Int
+            while (inputStream.read(buffer).also { readBytes = it } > 0) {
+                zipOutputStream.write(buffer, 0, readBytes)
+            }
+            inputStream.close()
+            zipOutputStream.closeEntry()
+        }
+    } catch (e: Exception) {
+        Timber.e(e, "Zip writing error")
+    } finally {
+        if (zipOutputStream != null) {
+            try {
+                zipOutputStream.close()
+            } catch (ignored: IOException) {
+            }
+        }
+    }
+
+    withContext(Dispatchers.Main) {
+        val targetUri = FileProvider.getUriForFile(context, "io.rebble.fossil.files", targetFile)
+
+        val activityIntent = Intent(Intent.ACTION_SEND)
+
+        activityIntent.putExtra(Intent.EXTRA_STREAM, targetUri)
+        activityIntent.setType("application/octet-stream")
+
+        activityIntent.setClipData(ClipData.newUri(context.getContentResolver(),
+                "Fossil Logs",
+                targetUri))
+
+        activityIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
+        val chooserIntent = Intent.createChooser(activityIntent, null)
+        chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+        context.startActivity(chooserIntent)
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/notifications/NotificationListener.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/notifications/NotificationListener.kt
@@ -2,19 +2,18 @@ package io.rebble.fossil.notifications
 
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
-import io.flutter.Log
 import io.rebble.fossil.FossilApplication
 import io.rebble.libpebblecommon.services.notification.NotificationService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class NotificationListener : NotificationListenerService() {
     private lateinit var coroutineScope: CoroutineScope
 
     private var isListening = false
-    private val logTag: String = "FossilNotifService"
 
     private var notifStates: MutableMap<NotificationKey, ParsedNotification> = mutableMapOf()
 
@@ -72,7 +71,7 @@ class NotificationListener : NotificationListenerService() {
 
     override fun onNotificationRemoved(sbn: StatusBarNotification) {
         if (isListening) {
-            Log.d(logTag, "Notification removed: ${sbn.packageName}")
+            Timber.d("Notification removed: ${sbn.packageName}")
 
             notifStates.remove(NotificationKey(sbn))
             //TODO: Dismissing on watch

--- a/android/app/src/main/kotlin/io/rebble/fossil/receivers/AppStartReceiver.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/receivers/AppStartReceiver.kt
@@ -1,0 +1,13 @@
+package io.rebble.fossil.receivers
+
+import android.annotation.SuppressLint
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class AppStartReceiver : BroadcastReceiver() {
+    @SuppressLint("UnsafeProtectedBroadcastReceiver")
+    override fun onReceive(context: Context?, intent: Intent?) {
+        // Do nothing. Application's onCreate takes care of the rest.
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/receivers/BluetoothAclReceiver.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/receivers/BluetoothAclReceiver.kt
@@ -1,0 +1,40 @@
+package io.rebble.fossil.receivers
+
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.rebble.fossil.FossilApplication
+import io.rebble.fossil.bluetooth.ConnectionState
+import kotlinx.coroutines.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BluetoothAclReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != BluetoothDevice.ACTION_ACL_CONNECTED) {
+            return
+        }
+
+        val device: BluetoothDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+                ?: return
+
+        val component = (context.applicationContext as FossilApplication).component
+
+        val pairedStorage = component.createPairedStorage()
+        val connectionLooper = component.createConnectionLooper()
+
+        if (pairedStorage.getMacAddressOfDefaultPebble() == device.address &&
+                connectionLooper.connectionState.value is ConnectionState.Connecting) {
+            // After ACL is established, Pebble still needs some time to initialize
+            // Attempt connection after one second
+
+            GlobalScope.launch(Dispatchers.Main) {
+                delay(1000)
+
+                if (connectionLooper.connectionState.value is ConnectionState.Connecting) {
+                    connectionLooper.connectToWatch(device.address)
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/util/MacAddresses.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/util/MacAddresses.kt
@@ -1,0 +1,16 @@
+package io.rebble.fossil.util
+
+fun String.macAddressToLong(): Long {
+    return replace(":", "").toLong(16)
+}
+
+fun Long.macAddressToString(): String {
+    val hex = "%X".format(this).padStart(12, '0')
+    var btaddr = ""
+    for (i in hex.indices) {
+        btaddr += hex[i]
+        if ((i + 1) % 2 == 0 && i + 1 < hex.length) btaddr += ":"
+    }
+
+    return btaddr
+}

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<paths>
+    <cache-path
+        name="logs"
+        path="logs/" />
+</paths>

--- a/lib/infrastructure/pigeons/pigeons.dart
+++ b/lib/infrastructure/pigeons/pigeons.dart
@@ -294,6 +294,27 @@ class ConnectionControl {
     }
     
   }
+  Future<void> disconnect() async {
+    const BasicMessageChannel<dynamic> channel =
+        BasicMessageChannel<dynamic>('dev.flutter.pigeon.ConnectionControl.disconnect', StandardMessageCodec());
+    
+    final Map<dynamic, dynamic> replyMap = await channel.send(null);
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+        details: null);
+    } else if (replyMap['error'] != null) {
+      final Map<dynamic, dynamic> error = replyMap['error'];
+      throw PlatformException(
+          code: error['code'],
+          message: error['message'],
+          details: error['details']);
+    } else {
+      // noop
+    }
+    
+  }
   Future<void> sendRawPacket(ListWrapper arg) async {
     final Map<dynamic, dynamic> requestMap = arg._toMap();
     const BasicMessageChannel<dynamic> channel =

--- a/lib/infrastructure/pigeons/pigeons.dart
+++ b/lib/infrastructure/pigeons/pigeons.dart
@@ -2,9 +2,8 @@
 // See also: https://pub.dev/packages/pigeon
 // ignore_for_file: public_member_api_docs, non_constant_identifier_names, avoid_as, unused_import
 import 'dart:async';
-import 'dart:typed_data' show Uint8List, Int32List, Int64List, Float64List;
-
 import 'package:flutter/services.dart';
+import 'dart:typed_data' show Uint8List, Int32List, Int64List, Float64List;
 
 class ListWrapper {
   List value;
@@ -35,7 +34,7 @@ class BooleanWrapper {
   }
   // ignore: unused_element
   static BooleanWrapper _fromMap(Map<dynamic, dynamic> pigeonMap) {
-    if (pigeonMap == null) {
+    if (pigeonMap == null){
       return null;
     }
     final BooleanWrapper result = BooleanWrapper();
@@ -48,7 +47,6 @@ class WatchConnectionState {
   bool isConnected;
   bool isConnecting;
   int currentWatchAddress;
-
   // ignore: unused_element
   Map<dynamic, dynamic> _toMap() {
     final Map<dynamic, dynamic> pigeonMap = <dynamic, dynamic>{};
@@ -57,10 +55,9 @@ class WatchConnectionState {
     pigeonMap['currentWatchAddress'] = currentWatchAddress;
     return pigeonMap;
   }
-
   // ignore: unused_element
   static WatchConnectionState _fromMap(Map<dynamic, dynamic> pigeonMap) {
-    if (pigeonMap == null) {
+    if (pigeonMap == null){
       return null;
     }
     final WatchConnectionState result = WatchConnectionState();
@@ -73,14 +70,12 @@ class WatchConnectionState {
 
 class NumberWrapper {
   int value;
-
   // ignore: unused_element
   Map<dynamic, dynamic> _toMap() {
     final Map<dynamic, dynamic> pigeonMap = <dynamic, dynamic>{};
     pigeonMap['value'] = value;
     return pigeonMap;
   }
-
   // ignore: unused_element
   static NumberWrapper _fromMap(Map<dynamic, dynamic> pigeonMap) {
     if (pigeonMap == null){
@@ -118,15 +113,15 @@ class NotificationsControl {
 
 class ScanControl {
   Future<void> startBleScan() async {
-    const BasicMessageChannel<dynamic> channel = BasicMessageChannel<dynamic>(
-        'dev.flutter.pigeon.ScanControl.startBleScan', StandardMessageCodec());
-
+    const BasicMessageChannel<dynamic> channel =
+        BasicMessageChannel<dynamic>('dev.flutter.pigeon.ScanControl.startBleScan', StandardMessageCodec());
+    
     final Map<dynamic, dynamic> replyMap = await channel.send(null);
     if (replyMap == null) {
       throw PlatformException(
-          code: 'channel-error',
-          message: 'Unable to establish connection on channel.',
-          details: null);
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+        details: null);
     } else if (replyMap['error'] != null) {
       final Map<dynamic, dynamic> error = replyMap['error'];
       throw PlatformException(
@@ -136,20 +131,18 @@ class ScanControl {
     } else {
       // noop
     }
+    
   }
-
   Future<void> startClassicScan() async {
     const BasicMessageChannel<dynamic> channel =
-    BasicMessageChannel<dynamic>(
-        'dev.flutter.pigeon.ScanControl.startClassicScan',
-        StandardMessageCodec());
-
+        BasicMessageChannel<dynamic>('dev.flutter.pigeon.ScanControl.startClassicScan', StandardMessageCodec());
+    
     final Map<dynamic, dynamic> replyMap = await channel.send(null);
     if (replyMap == null) {
       throw PlatformException(
-          code: 'channel-error',
-          message: 'Unable to establish connection on channel.',
-          details: null);
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+        details: null);
     } else if (replyMap['error'] != null) {
       final Map<dynamic, dynamic> error = replyMap['error'];
       throw PlatformException(
@@ -214,40 +207,58 @@ class AppLifecycleControl {
     } else {
       return BooleanWrapper._fromMap(replyMap['result']);
     }
+    
   }
 }
 
 abstract class ConnectionCallbacks {
   void onWatchConnectionStateChanged(WatchConnectionState arg);
-
   static void setup(ConnectionCallbacks api) {
     {
       const BasicMessageChannel<dynamic> channel =
-      BasicMessageChannel<dynamic>(
-          'dev.flutter.pigeon.ConnectionCallbacks.onWatchConnectionStateChanged',
-          StandardMessageCodec());
+          BasicMessageChannel<dynamic>('dev.flutter.pigeon.ConnectionCallbacks.onWatchConnectionStateChanged', StandardMessageCodec());
       channel.setMessageHandler((dynamic message) async {
-        final Map<dynamic, dynamic> mapMessage = message as Map<dynamic,
-            dynamic>;
-        final WatchConnectionState input = WatchConnectionState._fromMap(
-            mapMessage);
+        final Map<dynamic, dynamic> mapMessage = message as Map<dynamic, dynamic>;
+        final WatchConnectionState input = WatchConnectionState._fromMap(mapMessage);
         api.onWatchConnectionStateChanged(input);
       });
     }
   }
 }
 
-class ConnectionControl {
-  Future<BooleanWrapper> isConnected() async {
+class DebugControl {
+  Future<void> collectLogs() async {
     const BasicMessageChannel<dynamic> channel =
-    BasicMessageChannel<dynamic>(
-        'dev.flutter.pigeon.ConnectionControl.isConnected',
-        StandardMessageCodec());
-
+        BasicMessageChannel<dynamic>('dev.flutter.pigeon.DebugControl.collectLogs', StandardMessageCodec());
+    
     final Map<dynamic, dynamic> replyMap = await channel.send(null);
     if (replyMap == null) {
       throw PlatformException(
-          code: 'channel-error',
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+        details: null);
+    } else if (replyMap['error'] != null) {
+      final Map<dynamic, dynamic> error = replyMap['error'];
+      throw PlatformException(
+          code: error['code'],
+          message: error['message'],
+          details: error['details']);
+    } else {
+      // noop
+    }
+    
+  }
+}
+
+class ConnectionControl {
+  Future<BooleanWrapper> isConnected() async {
+    const BasicMessageChannel<dynamic> channel =
+        BasicMessageChannel<dynamic>('dev.flutter.pigeon.ConnectionControl.isConnected', StandardMessageCodec());
+    
+    final Map<dynamic, dynamic> replyMap = await channel.send(null);
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
         message: 'Unable to establish connection on channel.',
         details: null);
     } else if (replyMap['error'] != null) {

--- a/lib/infrastructure/pigeons/pigeons.dart
+++ b/lib/infrastructure/pigeons/pigeons.dart
@@ -8,14 +8,12 @@ import 'package:flutter/services.dart';
 
 class ListWrapper {
   List value;
-
   // ignore: unused_element
   Map<dynamic, dynamic> _toMap() {
     final Map<dynamic, dynamic> pigeonMap = <dynamic, dynamic>{};
     pigeonMap['value'] = value;
     return pigeonMap;
   }
-
   // ignore: unused_element
   static ListWrapper _fromMap(Map<dynamic, dynamic> pigeonMap) {
     if (pigeonMap == null){
@@ -37,7 +35,7 @@ class BooleanWrapper {
   }
   // ignore: unused_element
   static BooleanWrapper _fromMap(Map<dynamic, dynamic> pigeonMap) {
-    if (pigeonMap == null){
+    if (pigeonMap == null) {
       return null;
     }
     final BooleanWrapper result = BooleanWrapper();
@@ -46,14 +44,43 @@ class BooleanWrapper {
   }
 }
 
+class WatchConnectionState {
+  bool isConnected;
+  bool isConnecting;
+  int currentWatchAddress;
+
+  // ignore: unused_element
+  Map<dynamic, dynamic> _toMap() {
+    final Map<dynamic, dynamic> pigeonMap = <dynamic, dynamic>{};
+    pigeonMap['isConnected'] = isConnected;
+    pigeonMap['isConnecting'] = isConnecting;
+    pigeonMap['currentWatchAddress'] = currentWatchAddress;
+    return pigeonMap;
+  }
+
+  // ignore: unused_element
+  static WatchConnectionState _fromMap(Map<dynamic, dynamic> pigeonMap) {
+    if (pigeonMap == null) {
+      return null;
+    }
+    final WatchConnectionState result = WatchConnectionState();
+    result.isConnected = pigeonMap['isConnected'];
+    result.isConnecting = pigeonMap['isConnecting'];
+    result.currentWatchAddress = pigeonMap['currentWatchAddress'];
+    return result;
+  }
+}
+
 class NumberWrapper {
   int value;
+
   // ignore: unused_element
   Map<dynamic, dynamic> _toMap() {
     final Map<dynamic, dynamic> pigeonMap = <dynamic, dynamic>{};
     pigeonMap['value'] = value;
     return pigeonMap;
   }
+
   // ignore: unused_element
   static NumberWrapper _fromMap(Map<dynamic, dynamic> pigeonMap) {
     if (pigeonMap == null){
@@ -112,7 +139,8 @@ class ScanControl {
   }
 
   Future<void> startClassicScan() async {
-    const BasicMessageChannel<dynamic> channel = BasicMessageChannel<dynamic>(
+    const BasicMessageChannel<dynamic> channel =
+    BasicMessageChannel<dynamic>(
         'dev.flutter.pigeon.ScanControl.startClassicScan',
         StandardMessageCodec());
 
@@ -186,19 +214,40 @@ class AppLifecycleControl {
     } else {
       return BooleanWrapper._fromMap(replyMap['result']);
     }
-    
+  }
+}
+
+abstract class ConnectionCallbacks {
+  void onWatchConnectionStateChanged(WatchConnectionState arg);
+
+  static void setup(ConnectionCallbacks api) {
+    {
+      const BasicMessageChannel<dynamic> channel =
+      BasicMessageChannel<dynamic>(
+          'dev.flutter.pigeon.ConnectionCallbacks.onWatchConnectionStateChanged',
+          StandardMessageCodec());
+      channel.setMessageHandler((dynamic message) async {
+        final Map<dynamic, dynamic> mapMessage = message as Map<dynamic,
+            dynamic>;
+        final WatchConnectionState input = WatchConnectionState._fromMap(
+            mapMessage);
+        api.onWatchConnectionStateChanged(input);
+      });
+    }
   }
 }
 
 class ConnectionControl {
   Future<BooleanWrapper> isConnected() async {
     const BasicMessageChannel<dynamic> channel =
-        BasicMessageChannel<dynamic>('dev.flutter.pigeon.ConnectionControl.isConnected', StandardMessageCodec());
-    
+    BasicMessageChannel<dynamic>(
+        'dev.flutter.pigeon.ConnectionControl.isConnected',
+        StandardMessageCodec());
+
     final Map<dynamic, dynamic> replyMap = await channel.send(null);
     if (replyMap == null) {
       throw PlatformException(
-        code: 'channel-error',
+          code: 'channel-error',
         message: 'Unable to establish connection on channel.',
         details: null);
     } else if (replyMap['error'] != null) {

--- a/lib/ui/home/tabs/TestTab.dart
+++ b/lib/ui/home/tabs/TestTab.dart
@@ -10,6 +10,7 @@ class TestTab extends StatefulWidget {
 class _TestTabState extends State<TestTab> implements ConnectionCallbacks {
   WatchConnectionState connectionState = new WatchConnectionState();
   final NotificationsControl notifications = NotificationsControl();
+  final DebugControl debug = DebugControl();
 
   @override
   void initState() {
@@ -39,6 +40,12 @@ class _TestTabState extends State<TestTab> implements ConnectionCallbacks {
                 notifications.sendTestNotification();
               },
               child: Text("Button"),
+            ),
+            RaisedButton(
+              onPressed: () {
+                debug.collectLogs();
+              },
+              child: Text("Send logs"),
             ),
             Text(statusText),
             Card(

--- a/lib/ui/home/tabs/TestTab.dart
+++ b/lib/ui/home/tabs/TestTab.dart
@@ -2,11 +2,31 @@ import 'package:flutter/material.dart';
 import 'package:fossil/infrastructure/pigeons/pigeons.dart';
 import 'package:fossil/ui/common/icons/fonts/RebbleIconsStroke.dart';
 
-class TestTab extends StatelessWidget {
+class TestTab extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _TestTabState();
+}
+
+class _TestTabState extends State<TestTab> implements ConnectionCallbacks {
+  WatchConnectionState connectionState = new WatchConnectionState();
   final NotificationsControl notifications = NotificationsControl();
 
   @override
+  void initState() {
+    ConnectionCallbacks.setup(this);
+  }
+
+  @override
   Widget build(BuildContext context) {
+    String statusText;
+    if (connectionState.isConnecting == true) {
+      statusText = "Connecting to ${connectionState.currentWatchAddress}";
+    } else if (connectionState.isConnected == true) {
+      statusText = "Connected to ${connectionState.currentWatchAddress}";
+    } else {
+      statusText = "Disconnected";
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text("Testing"),
@@ -20,7 +40,7 @@ class TestTab extends StatelessWidget {
               },
               child: Text("Button"),
             ),
-            Text("This is some text."),
+            Text(statusText),
             Card(
               margin: EdgeInsets.all(16.0),
               child: Padding(
@@ -29,20 +49,24 @@ class TestTab extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
                     Row(),
-                    Text("Some debug options", style: Theme.of(context).textTheme.headline5,),
+                    Text(
+                      "Some debug options",
+                      style: Theme.of(context).textTheme.headline5,
+                    ),
                     SizedBox(height: 8.0),
                     FlatButton.icon(
                         label: Text("Open developer options"),
-                        icon: Icon(RebbleIconsStroke.developer_connection_console, size: 25.0),
+                        icon: Icon(
+                            RebbleIconsStroke.developer_connection_console,
+                            size: 25.0),
                         textColor: Theme.of(context).accentColor,
-                        onPressed: () => Navigator.pushNamed(context, '/devoptions')
-                    ),
+                        onPressed: () =>
+                            Navigator.pushNamed(context, '/devoptions')),
                     FlatButton.icon(
                         label: Text("Here's another button"),
                         icon: Icon(RebbleIconsStroke.settings, size: 25.0),
                         textColor: Theme.of(context).accentColor,
-                        onPressed: () => {}
-                    ),
+                        onPressed: () => {}),
                   ],
                 ),
               ),
@@ -51,5 +75,12 @@ class TestTab extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  @override
+  void onWatchConnectionStateChanged(WatchConnectionState newState) {
+    setState(() {
+      connectionState = newState;
+    });
   }
 }

--- a/lib/ui/splash/SplashPage.dart
+++ b/lib/ui/splash/SplashPage.dart
@@ -11,22 +11,12 @@ class SplashPage extends StatefulWidget {
 }
 
 class _SplashPageState extends State<SplashPage> {
-  final ConnectionControl connectionControl = ConnectionControl();
-
   void _openHome() {
     SharedPreferences.getInstance().then((prefs) => {
           if (!prefs.containsKey("firstRun"))
             Navigator.pushReplacementNamed(context, '/firstrun')
           else
             {
-              PairedStorage.getDefault().then((value) {
-                if (value != null) {
-                  NumberWrapper addressWrapper = NumberWrapper();
-                  addressWrapper.value = value.address;
-
-                  connectionControl.connectToWatch(addressWrapper);
-                }
-              }),
               Navigator.pushReplacementNamed(context, '/home')
             }
         });

--- a/pigeons/pigeons.dart
+++ b/pigeons/pigeons.dart
@@ -47,6 +47,8 @@ abstract class ConnectionControl {
 
   void connectToWatch(NumberWrapper macAddress);
 
+  void disconnect();
+
   void sendRawPacket(ListWrapper listOfBytes);
 }
 

--- a/pigeons/pigeons.dart
+++ b/pigeons/pigeons.dart
@@ -59,3 +59,8 @@ abstract class NotificationsControl {
 abstract class AppLifecycleControl {
   BooleanWrapper waitForBoot();
 }
+
+@HostApi()
+abstract class DebugControl {
+  void collectLogs();
+}

--- a/pigeons/pigeons.dart
+++ b/pigeons/pigeons.dart
@@ -14,6 +14,12 @@ class ListWrapper {
   List value;
 }
 
+class WatchConnectionState {
+  bool isConnected;
+  bool isConnecting;
+  int currentWatchAddress;
+}
+
 @FlutterApi()
 abstract class ScanCallbacks {
   void onScanUpdate(ListWrapper pebbles);
@@ -21,6 +27,11 @@ abstract class ScanCallbacks {
   void onScanStarted();
 
   void onScanStopped();
+}
+
+@FlutterApi()
+abstract class ConnectionCallbacks {
+  void onWatchConnectionStateChanged(WatchConnectionState newState);
 }
 
 @HostApi()


### PR DESCRIPTION
As usual, check commit messages for detailed list. Remarks:

* After this PR, there is an extra pairing step. After user selects the watch, he/she must confirm to connect to the watch via Android system dialog. This is required for us to use Android's CompanionDeviceManager which has quite a few benefits (for example much more user-friendly flow for enabling notification listener service). We might need to adjust designs to accommodate this
* I've moved logging to Timber. App now creates logfile in data folder and there is a button on the Testing screen that allows you to share logs out of the app. This will allow us to test app in the wild without being tethered to the PC to constantly observe logs. Log sharing code should eventually be moved to flutter, but I do not know enough about Flutter, so I whipped it up it in native Kotlin for now.