### PR TITLE
Add basic PebbleKit support

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -73,7 +73,7 @@ flutter {
     source '../..'
 }
 
-def libpebblecommon_version = '0.0.6'
+def libpebblecommon_version = '0.0.7'
 def coroutinesVersion = "1.3.9"
 def lifecycleVersion = "2.2.0"
 def timberVersion = "4.7.1"
@@ -94,4 +94,6 @@ dependencies {
 
     implementation 'com.google.dagger:dagger:2.29.1'
     kapt 'com.google.dagger:dagger-compiler:2.29.1'
+
+    testImplementation 'junit:junit:4.13'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="io.rebble.fossil">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
@@ -100,5 +101,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <provider
+            android:authorities="com.getpebble.android.provider.basalt"
+            android:name=".providers.PebbleKitProvider"
+            tools:ignore="ExportedContentProvider"
+            android:exported="true" />
     </application>
 </manifest>

--- a/android/app/src/main/java/com/getpebble/android/kit/Constants.java
+++ b/android/app/src/main/java/com/getpebble/android/kit/Constants.java
@@ -381,5 +381,5 @@ public final class Constants {
 
     /* package */ static final Uri URI_CONTENT_PRIMARY = Uri.parse("content://com.getpebble.android.provider/state");
 
-    /* package */ static final Uri URI_CONTENT_BASALT = Uri.parse("content://com.getpebble.android.provider.basalt/state");
+    public static final Uri URI_CONTENT_BASALT = Uri.parse("content://com.getpebble.android.provider.basalt/state");
 }

--- a/android/app/src/main/java/com/getpebble/android/kit/Constants.java
+++ b/android/app/src/main/java/com/getpebble/android/kit/Constants.java
@@ -1,0 +1,385 @@
+package com.getpebble.android.kit;
+
+import android.net.Uri;
+
+import java.util.UUID;
+
+/**
+ * Constant values used by PebbleKit-enabled android applications.
+ */
+public final class Constants {
+
+    /**
+     * Intent broadcast by pebble.apk when a new connection to a Pebble is established.
+     */
+    public static final String INTENT_PEBBLE_CONNECTED = "com.getpebble.action.PEBBLE_CONNECTED";
+    /**
+     * Intent broadcast by pebble.apk when the connection to a Pebble is closed or lost.
+     */
+    public static final String INTENT_PEBBLE_DISCONNECTED = "com.getpebble.action.PEBBLE_DISCONNECTED";
+
+    /**
+     * Intent broadcast to pebble.apk to indicate that a message was received from the watch. To avoid protocol timeouts
+     * on the watch, applications <em>must</em> ACK or NACK all received messages.
+     */
+    public static final String INTENT_APP_ACK = "com.getpebble.action.app.ACK";
+
+    /**
+     * Intent broadcast to pebble.apk to indicate that a message was unsuccessfully received from the watch.
+     */
+    public static final String INTENT_APP_NACK = "com.getpebble.action.app.NACK";
+
+    /**
+     * Intent broadcast from pebble.apk containing one-or-more key-value pairs sent from the watch to the phone.
+     */
+    public static final String INTENT_APP_RECEIVE = "com.getpebble.action.app.RECEIVE";
+
+
+    /**
+     * Intent broadcast from pebble.apk indicating that a sent message was successfully received by a watch app.
+     */
+    public static final String INTENT_APP_RECEIVE_ACK = "com.getpebble.action.app.RECEIVE_ACK";
+
+    /**
+     * Intent broadcast from pebble.apk indicating that a sent message was not received by a watch app.
+     */
+    public static final String INTENT_APP_RECEIVE_NACK = "com.getpebble.action.app.RECEIVE_NACK";
+
+    /**
+     * Intent broadcast to pebble.apk containing one-or-more key-value pairs to be sent to the watch from the phone.
+     */
+    public static final String INTENT_APP_SEND = "com.getpebble.action.app.SEND";
+
+    /**
+     * Intent broadcast to pebble.apk responsible for launching a watch-app on the connected watch. This intent is
+     * idempotent.
+     */
+    public static final String INTENT_APP_START = "com.getpebble.action.app.START";
+
+    /**
+     * Intent broadcast to pebble.apk responsible for closing a running watch-app on the connected watch. This intent is
+     * idempotent.
+     */
+    public static final String INTENT_APP_STOP = "com.getpebble.action.app.STOP";
+
+    /**
+     * Intent broadcast to pebble.apk responsible for customizing the name and icon of the 'stock' Sports and Golf
+     * applications included in the watch's firmware.
+     */
+    public static final String INTENT_APP_CUSTOMIZE = "com.getpebble.action.app.CONFIGURE";
+
+    /**
+     * Intent broadcast from pebble.apk containing a unit of data from a data log.
+     */
+    public static final String INTENT_DL_RECEIVE_DATA = "com.getpebble.action.dl.RECEIVE_DATA_NEW";
+
+    /**
+     * Intent broadcast to pebble.apk implicitly when a unit of data from a data log is received.
+     */
+    public static final String INTENT_DL_ACK_DATA = "com.getpebble.action.dl.ACK_DATA";
+
+    /**
+     * Intent broadcast to pebble.apk to request data logs for a particular app.
+     */
+    public static final String INTENT_DL_REQUEST_DATA = "com.getpebble.action.dl.REQUEST_DATA";
+
+    /**
+     * Intent broadcast from pebble.apk indicating the session has finished.
+     */
+    public static final String INTENT_DL_FINISH_SESSION = "com.getpebble.action.dl.FINISH_SESSION_NEW";
+
+    /**
+     * The UUID corresponding to Pebble's built-in "Sports" application.
+     */
+    public static final UUID SPORTS_UUID = UUID.fromString("4dab81a6-d2fc-458a-992c-7a1f3b96a970");
+
+    /**
+     * The UUID corresponding to Pebble's built-in "Golf" application.
+     */
+    public static final UUID GOLF_UUID = UUID.fromString("cf1e816a-9db0-4511-bbb8-f60c48ca8fac");
+
+    /**
+     * The bundle-key used to store a message's transaction id.
+     */
+    public static final String TRANSACTION_ID = "transaction_id";
+
+    /**
+     * The bundle-key used to store a message's UUID.
+     */
+    public static final String APP_UUID = "uuid";
+
+    /**
+     * The bundle-key used to store a message's JSON payload send-to or received-from the watch.
+     */
+    public static final String MSG_DATA = "msg_data";
+
+    /**
+     * The bundle-key used to store the type of application being customized in a CUSTOMIZE intent.
+     */
+    public static final String CUST_APP_TYPE = "app_type";
+
+    /**
+     * The bundle-key used to store the custom name provided in a CUSTOMIZE intent.
+     */
+    public static final String CUST_NAME = "name";
+
+    /**
+     * The bundle-key used to store the custom icon provided in a CUSTOMIZE intent.
+     */
+    public static final String CUST_ICON = "icon";
+
+    /**
+     * The bundle-key used to store the timestamp of when a data log was first created.
+     */
+    public static final String DATA_LOG_TIMESTAMP = "data_log_timestamp";
+
+    /**
+     * A bundle-key used to store the UUID that uniquely identifies a data log.
+     */
+    public static final String DATA_LOG_UUID = "data_log_uuid";
+
+    /**
+     * A bundle-key used to store the tag for the corresponding data log.
+     */
+    public static final String DATA_LOG_TAG = "data_log_tag";
+
+    /**
+     * A bundle-key used to store the ID of a unit of data in a data log.
+     */
+    public static final String PBL_DATA_ID = "pbl_data_id";
+
+    /**
+     * A bundle-key used to store the data type of the data unit.
+     */
+    public static final String PBL_DATA_TYPE = "pbl_data_type";
+
+    /**
+     * A bundle-key used to store the value of the data unit.
+     */
+    public static final String PBL_DATA_OBJECT = "pbl_data_object";
+
+    /**
+     * The PebbleDictionary key corresponding to the 'time' field sent to the Sports watch-app.
+     */
+    public static final int SPORTS_TIME_KEY = 0x00;
+    /**
+     * The PebbleDictionary key corresponding to the 'distance' field sent to the Sports watch-app.
+     */
+    public static final int SPORTS_DISTANCE_KEY = 0x01;
+    /**
+     * The PebbleDictionary key corresponding to the 'data' field sent to the Sports watch-app. The data field is paired
+     * with the label specified by SPORTS_LABEL_KEY and can be used to display speed or pace data.
+     */
+    public static final int SPORTS_DATA_KEY = 0x02;
+    /**
+     * The PebbleDictionary key corresponding to the 'units' field sent to the Sports watch-app.
+     */
+    public static final int SPORTS_UNITS_KEY = 0x03;
+    /**
+     * The PebbleDictionary key corresponding to the 'state' field sent to the Sports watch-app. Both the watch and
+     * phone-app may modify this field. The phone-application is responsible for performing any required state
+     * transitions to stay in sync with the watch-app's state.
+     */
+    public static final int SPORTS_STATE_KEY = 0x04;
+    /**
+     * The PebbleDictionary key corresponding to the 'label' field sent to the Sports watch-app. The label field
+     * controls the label above the 'data' field.
+     */
+    public static final int SPORTS_LABEL_KEY = 0x05;
+    /**
+     * The PebbleDictionary key corresponding to the 'heart rate' field sent to the Sports watch-app. The heart rate
+     * field controls the data displayed in the scrollable field containing heart rate bpm.
+     */
+    public static final int SPORTS_HR_BPM_KEY = 0x06;
+    /**
+     * The PebbleDictionary key corresponding to the custom label field sent to the Sports watch-app. This label field
+     * controls the label above the custom value field.
+     */
+    public static final int SPORTS_CUSTOM_LABEL_KEY = 0x07;
+    /**
+     * The PebbleDictionary key corresponding to the custom value sent to the Sports watch-app. The custom value field
+     * controls the data displayed in the scrollable field containing custom data.
+     */
+    public static final int SPORTS_CUSTOM_VALUE_KEY = 0x08;
+
+    /**
+     * PebbleDictionary value corresponding to 'imperial' units.
+     */
+    public static final int SPORTS_UNITS_IMPERIAL = 0x00;
+    /**
+     * PebbleDictionary value corresponding to 'metric' units.
+     */
+    public static final int SPORTS_UNITS_METRIC = 0x01;
+    /**
+     * PebbleDictionary value corresponding to 'speed' data.
+     */
+    public static final int SPORTS_DATA_SPEED = 0x00;
+    /**
+     * PebbleDictionary value corresponding to 'pace' data.
+     */
+    public static final int SPORTS_DATA_PACE = 0x01;
+
+    /**
+     * The Constant SPORTS_STATE_INIT.
+     */
+    public static final int SPORTS_STATE_INIT = 0x00;
+
+    /**
+     * The Constant SPORTS_STATE_RUNNING.
+     */
+    public static final int SPORTS_STATE_RUNNING = 0x01;
+
+    /**
+     * The Constant SPORTS_STATE_PAUSED.
+     */
+    public static final int SPORTS_STATE_PAUSED = 0x02;
+
+    /**
+     * The Constant SPORTS_STATE_END.
+     */
+    public static final int SPORTS_STATE_END = 0x03;
+
+    /**
+     * The Constant GOLF_FRONT_KEY.
+     */
+    public static final int GOLF_FRONT_KEY = 0x00;
+
+    /**
+     * The Constant GOLF_MID_KEY.
+     */
+    public static final int GOLF_MID_KEY = 0x01;
+
+    /**
+     * The Constant GOLF_BACK_KEY.
+     */
+    public static final int GOLF_BACK_KEY = 0x02;
+
+    /**
+     * The Constant GOLF_HOLE_KEY.
+     */
+    public static final int GOLF_HOLE_KEY = 0x03;
+
+    /**
+     * The Constant GOLF_PAR_KEY.
+     */
+    public static final int GOLF_PAR_KEY = 0x04;
+
+    /**
+     * The Constant GOLF_CMD_KEY.
+     */
+    public static final int GOLF_CMD_KEY = 0x05;
+
+    /**
+     * Command sent by the golf-application to display the next hole.
+     */
+    public static final int GOLF_CMD_PREV = 0x01;
+
+    /**
+     * Command sent by the golf-application to display the previous hole.
+     */
+    public static final int GOLF_CMD_NEXT = 0x02;
+
+
+    public static final int KIT_STATE_COLUMN_CONNECTED = 0;
+    public static final int KIT_STATE_COLUMN_APPMSG_SUPPORT = 1;
+    public static final int KIT_STATE_COLUMN_DATALOGGING_SUPPORT = 2;
+    public static final int KIT_STATE_COLUMN_VERSION_MAJOR = 3;
+    public static final int KIT_STATE_COLUMN_VERSION_MINOR = 4;
+    public static final int KIT_STATE_COLUMN_VERSION_POINT = 5;
+    public static final int KIT_STATE_COLUMN_VERSION_TAG = 6;
+
+    /**
+     * Instantiates a new constants.
+     */
+    private Constants() {
+
+    }
+
+    /**
+     * The Enum PebbleAppType.
+     */
+    public static enum PebbleAppType {
+
+        /**
+         * The sports.
+         */
+        SPORTS(0x00),
+
+        /**
+         * The golf.
+         */
+        GOLF(0x01),
+
+        /**
+         * The other.
+         */
+        OTHER(0xff);
+
+        /**
+         * The ord.
+         */
+        public final int ord;
+
+        /**
+         * Instantiates a new pebble app type.
+         *
+         * @param ord the ord
+         */
+        private PebbleAppType(final int ord) {
+            this.ord = ord;
+        }
+    }
+
+    /**
+     * The Enum PebbleDataType.
+     */
+    public static enum PebbleDataType {
+        /**
+         * The byte[].
+         */
+        BYTES(0x00),
+
+        /**
+         * The UnsignedInteger.
+         */
+        UINT(0x02),
+
+        /**
+         * The Integer.
+         */
+        INT(0x03),
+
+        /**
+         * The Invalid.
+         */
+        INVALID(0xff);
+
+        /**
+         * The ord.
+         */
+        public final byte ord;
+
+        /**
+         * Instantiates a new pebble data type.
+         */
+        private PebbleDataType(int ord) {
+            this.ord = (byte) ord;
+        }
+
+        /**
+         * Instantiates a new pebble data type from a byte.
+         */
+        public static PebbleDataType fromByte(byte b) {
+            for (PebbleDataType type : values()) {
+                if (type.ord == b) {
+                    return type;
+                }
+            }
+            return null;
+        }
+    }
+
+    /* package */ static final Uri URI_CONTENT_PRIMARY = Uri.parse("content://com.getpebble.android.provider/state");
+
+    /* package */ static final Uri URI_CONTENT_BASALT = Uri.parse("content://com.getpebble.android.provider.basalt/state");
+}

--- a/android/app/src/main/java/com/getpebble/android/kit/PebbleKit.java
+++ b/android/app/src/main/java/com/getpebble/android/kit/PebbleKit.java
@@ -1,0 +1,882 @@
+package com.getpebble.android.kit;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.util.Base64;
+import android.util.Log;
+
+import com.getpebble.android.kit.Constants.PebbleAppType;
+import com.getpebble.android.kit.Constants.PebbleDataType;
+import com.getpebble.android.kit.util.PebbleDictionary;
+
+import org.json.JSONException;
+
+import java.util.UUID;
+
+import static com.getpebble.android.kit.Constants.APP_UUID;
+import static com.getpebble.android.kit.Constants.CUST_APP_TYPE;
+import static com.getpebble.android.kit.Constants.CUST_ICON;
+import static com.getpebble.android.kit.Constants.CUST_NAME;
+import static com.getpebble.android.kit.Constants.DATA_LOG_TAG;
+import static com.getpebble.android.kit.Constants.DATA_LOG_TIMESTAMP;
+import static com.getpebble.android.kit.Constants.DATA_LOG_UUID;
+import static com.getpebble.android.kit.Constants.INTENT_APP_ACK;
+import static com.getpebble.android.kit.Constants.INTENT_APP_CUSTOMIZE;
+import static com.getpebble.android.kit.Constants.INTENT_APP_NACK;
+import static com.getpebble.android.kit.Constants.INTENT_APP_RECEIVE;
+import static com.getpebble.android.kit.Constants.INTENT_APP_RECEIVE_ACK;
+import static com.getpebble.android.kit.Constants.INTENT_APP_RECEIVE_NACK;
+import static com.getpebble.android.kit.Constants.INTENT_APP_SEND;
+import static com.getpebble.android.kit.Constants.INTENT_APP_START;
+import static com.getpebble.android.kit.Constants.INTENT_APP_STOP;
+import static com.getpebble.android.kit.Constants.INTENT_DL_ACK_DATA;
+import static com.getpebble.android.kit.Constants.INTENT_DL_FINISH_SESSION;
+import static com.getpebble.android.kit.Constants.INTENT_DL_RECEIVE_DATA;
+import static com.getpebble.android.kit.Constants.INTENT_DL_REQUEST_DATA;
+import static com.getpebble.android.kit.Constants.INTENT_PEBBLE_CONNECTED;
+import static com.getpebble.android.kit.Constants.INTENT_PEBBLE_DISCONNECTED;
+import static com.getpebble.android.kit.Constants.KIT_STATE_COLUMN_APPMSG_SUPPORT;
+import static com.getpebble.android.kit.Constants.KIT_STATE_COLUMN_CONNECTED;
+import static com.getpebble.android.kit.Constants.KIT_STATE_COLUMN_DATALOGGING_SUPPORT;
+import static com.getpebble.android.kit.Constants.KIT_STATE_COLUMN_VERSION_MAJOR;
+import static com.getpebble.android.kit.Constants.KIT_STATE_COLUMN_VERSION_MINOR;
+import static com.getpebble.android.kit.Constants.KIT_STATE_COLUMN_VERSION_POINT;
+import static com.getpebble.android.kit.Constants.KIT_STATE_COLUMN_VERSION_TAG;
+import static com.getpebble.android.kit.Constants.MSG_DATA;
+import static com.getpebble.android.kit.Constants.PBL_DATA_ID;
+import static com.getpebble.android.kit.Constants.PBL_DATA_OBJECT;
+import static com.getpebble.android.kit.Constants.PBL_DATA_TYPE;
+import static com.getpebble.android.kit.Constants.TRANSACTION_ID;
+
+/**
+ * A helper class providing methods for interacting with third-party Pebble Smartwatch applications. Pebble-enabled
+ * Android applications may use this class to assist in sending/receiving data between the watch and the phone.
+ */
+public final class PebbleKit {
+
+    /**
+     * The Constant NAME_MAX_LENGTH.
+     */
+    private static final int NAME_MAX_LENGTH = 32;
+
+    /**
+     * The Constant ICON_MAX_DIMENSIONS.
+     */
+    private static final int ICON_MAX_DIMENSIONS = 25;
+
+    /**
+     * Instantiates a new pebble kit.
+     */
+    private PebbleKit() {
+
+    }
+
+    /**
+     * Send a message to the connected Pebble to "customize" a built-in PebbleKit watch-app. This is intended to allow
+     * third-party Android applications to apply custom branding (both name and icon) on the watch without needing to
+     * distribute a complete watch-app.
+     *
+     * @param context The context used to send the broadcast. (Protip: pass in the ApplicationContext here.)
+     * @param appType The watch-app to be configured. Options are either
+     * @param name    The custom name to be applied to the watch-app. Names must be less than 32 characters in length.
+     * @param icon    The custom icon to be applied to the watch-app. Icons must be black-and-white bitmaps no larger than 32px
+     *                in either dimension.
+     * @throws IllegalArgumentException Thrown if the specified name or icon are invalid. {@link PebbleAppType#SPORTS} or {@link
+     *                                  PebbleAppType#GOLF}.
+     */
+    public static void customizeWatchApp(final Context context, final PebbleAppType appType,
+                                         final String name, final Bitmap icon) throws IllegalArgumentException {
+
+        if (appType == null) {
+            throw new IllegalArgumentException("app type cannot be null");
+        }
+
+        if (name.length() > NAME_MAX_LENGTH) {
+            throw new IllegalArgumentException(String.format(
+                    "app name exceeds maximum length (%d)", NAME_MAX_LENGTH));
+        }
+
+        if (icon.getHeight() > ICON_MAX_DIMENSIONS || icon.getWidth() > ICON_MAX_DIMENSIONS) {
+            throw new IllegalArgumentException(String.format(
+                    "app icon exceeds maximum dimensions (25px x 25px); got (%dpx x %dpx)",
+                    icon.getWidth(), icon.getHeight()));
+        }
+
+        final Intent customizeAppIntent = new Intent(INTENT_APP_CUSTOMIZE);
+        customizeAppIntent.putExtra(CUST_APP_TYPE, appType.ord);
+        customizeAppIntent.putExtra(CUST_NAME, name);
+        customizeAppIntent.putExtra(CUST_ICON, icon);
+        context.sendBroadcast(customizeAppIntent);
+    }
+
+    /**
+     * Synchronously query the Pebble application to see if an active Bluetooth connection to a watch currently exists.
+     *
+     * @param context The Android context used to perform the query.
+     *
+     *                <em>Protip:</em> You probably want to use your ApplicationContext here.
+     * @return true if an active connection to the watch currently exists, otherwise false. This method will also return
+     * false if the Pebble application is not installed on the user's handset.
+     */
+    public static boolean isWatchConnected(final Context context) {
+        Cursor c = null;
+        try {
+            c = queryProvider(context);
+            if (c == null || !c.moveToNext()) {
+                return false;
+            }
+            return c.getInt(KIT_STATE_COLUMN_CONNECTED) == 1;
+        } finally {
+            if (c != null) {
+                c.close();
+            }
+        }
+    }
+
+    /**
+     * Synchronously query the Pebble application to see if the connected watch is running a firmware version that
+     * supports PebbleKit messages.
+     *
+     * @param context The Android context used to perform the query.
+     *
+     *                <em>Protip:</em> You probably want to use your ApplicationContext here.
+     * @return true if the watch supports PebbleKit messages, otherwise false. This method will always return false if
+     * no Pebble is currently connected to the handset.
+     */
+    public static boolean areAppMessagesSupported(final Context context) {
+        Cursor c = null;
+        try {
+            c = queryProvider(context);
+            if (c == null || !c.moveToNext()) {
+                return false;
+            }
+            return c.getInt(KIT_STATE_COLUMN_APPMSG_SUPPORT) == 1;
+        } finally {
+            if (c != null) {
+                c.close();
+            }
+        }
+    }
+
+
+    /**
+     * Get the version information of the firmware running on a connected watch.
+     *
+     * @param context The Android context used to perform the query.
+     *
+     *                <em>Protip:</em> You probably want to use your ApplicationContext here.
+     * @return null if the watch is disconnected or we can't get the version. Otherwise,
+     * a FirmwareVersionObject containing info on the watch FW version
+     */
+    public static FirmwareVersionInfo getWatchFWVersion(final Context context) {
+        Cursor c = null;
+        try {
+            c = queryProvider(context);
+            if (c == null || !c.moveToNext()) {
+                return null;
+            }
+
+            int majorVersion = c.getInt(KIT_STATE_COLUMN_VERSION_MAJOR);
+            int minorVersion = c.getInt(KIT_STATE_COLUMN_VERSION_MINOR);
+            int pointVersion = c.getInt(KIT_STATE_COLUMN_VERSION_POINT);
+            String versionTag = c.getString(KIT_STATE_COLUMN_VERSION_TAG);
+
+            return new FirmwareVersionInfo(majorVersion, minorVersion, pointVersion, versionTag);
+        } finally {
+            if (c != null) {
+                c.close();
+            }
+        }
+    }
+
+    /**
+     * Synchronously query the Pebble application to see if the connected watch is running a firmware version that
+     * supports PebbleKit data logging.
+     *
+     * @param context The Android context used to perform the query.
+     *
+     *                <em>Protip:</em> You probably want to use your ApplicationContext here.
+     * @return true if the watch supports PebbleKit messages, otherwise false. This method will always return false if
+     * no Pebble is currently connected to the handset.
+     */
+    public static boolean isDataLoggingSupported(final Context context) {
+        Cursor c = null;
+        try {
+            c = queryProvider(context);
+            if (c == null || !c.moveToNext()) {
+                return false;
+            }
+            return c.getInt(KIT_STATE_COLUMN_DATALOGGING_SUPPORT) == 1;
+        } finally {
+            if (c != null) {
+                c.close();
+            }
+        }
+    }
+
+    /**
+     * Send a message to the connected Pebble to launch an application identified by a UUID. If another application is
+     * currently running it will be terminated and the new application will be brought to the foreground.
+     *
+     * @param context      The context used to send the broadcast.
+     * @param watchappUuid A UUID uniquely identifying the target application. UUIDs for the stock PebbleKit applications are
+     *                     available in {@link Constants}.
+     * @throws IllegalArgumentException Thrown if the specified UUID is invalid.
+     */
+    public static void startAppOnPebble(final Context context, final UUID watchappUuid)
+            throws IllegalArgumentException {
+
+        if (watchappUuid == null) {
+            throw new IllegalArgumentException("uuid cannot be null");
+        }
+
+        final Intent startAppIntent = new Intent(INTENT_APP_START);
+        startAppIntent.putExtra(APP_UUID, watchappUuid);
+        context.sendBroadcast(startAppIntent);
+    }
+
+    /**
+     * Send a message to the connected Pebble to close an application identified by a UUID. If this application is not
+     * currently running, the message is ignored.
+     *
+     * @param context      The context used to send the broadcast.
+     * @param watchappUuid A UUID uniquely identifying the target application. UUIDs for the stock kit applications are available in
+     *                     {@link Constants}.
+     * @throws IllegalArgumentException Thrown if the specified UUID is invalid.
+     */
+    public static void closeAppOnPebble(final Context context, final UUID watchappUuid)
+            throws IllegalArgumentException {
+
+        if (watchappUuid == null) {
+            throw new IllegalArgumentException("uuid cannot be null");
+        }
+
+        final Intent stopAppIntent = new Intent(INTENT_APP_STOP);
+        stopAppIntent.putExtra(APP_UUID, watchappUuid);
+        context.sendBroadcast(stopAppIntent);
+    }
+
+    /**
+     * Send one-or-more key-value pairs to the watch-app identified by the provided UUID. This is the primary method for
+     * sending data from the phone to a connected Pebble.
+     * <p>
+     * The watch-app and phone-app must agree of the set and type of key-value pairs being exchanged. Type mismatches or
+     * missing keys will cause errors on the receiver's end.
+     *
+     * @param context      The context used to send the broadcast.
+     * @param watchappUuid A UUID uniquely identifying the target application. UUIDs for the stock kit applications are available in
+     *                     {@link Constants}.
+     * @param data         A dictionary containing one-or-more key-value pairs. For more information about the types of data that
+     *                     can be stored, see {@link PebbleDictionary}.
+     * @throws IllegalArgumentException Thrown in the specified PebbleDictionary or UUID is invalid.
+     */
+    public static void sendDataToPebble(final Context context, final UUID watchappUuid,
+                                        final PebbleDictionary data) throws IllegalArgumentException {
+
+        sendDataToPebbleWithTransactionId(context, watchappUuid, data, -1);
+    }
+
+    /**
+     * Send one-or-more key-value pairs to the watch-app identified by the provided UUID.
+     * <p>
+     * The watch-app and phone-app must agree of the set and type of key-value pairs being exchanged. Type mismatches or
+     * missing keys will cause errors on the receiver's end.
+     *
+     * @param context       The context used to send the broadcast.
+     * @param watchappUuid  A UUID uniquely identifying the target application. UUIDs for the stock kit applications are available in
+     *                      {@link Constants}.
+     * @param data          A dictionary containing one-or-more key-value pairs. For more information about the types of data that
+     *                      can be stored, see {@link PebbleDictionary}.
+     * @param transactionId An integer uniquely identifying the transaction. This can be used to correlate messages sent to the
+     *                      Pebble and ACK/NACKs received from the Pebble.
+     * @throws IllegalArgumentException Thrown in the specified PebbleDictionary or UUID is invalid.
+     */
+    public static void sendDataToPebbleWithTransactionId(final Context context,
+                                                         final UUID watchappUuid, final PebbleDictionary data, final int transactionId)
+            throws IllegalArgumentException {
+
+        if (watchappUuid == null) {
+            throw new IllegalArgumentException("uuid cannot be null");
+        }
+
+        if (data == null) {
+            throw new IllegalArgumentException("data cannot be null");
+        }
+
+        if (data.size() == 0) {
+            return;
+        }
+
+        final Intent sendDataIntent = new Intent(INTENT_APP_SEND);
+        sendDataIntent.putExtra(APP_UUID, watchappUuid);
+        sendDataIntent.putExtra(TRANSACTION_ID, transactionId);
+        sendDataIntent.putExtra(MSG_DATA, data.toJsonString());
+        context.sendBroadcast(sendDataIntent);
+    }
+
+    /**
+     * Send a message to the connected watch acknowledging the receipt of a PebbleDictionary. To avoid protocol timeouts
+     * on the watch, applications <em>must</em> ACK or NACK all received messages.
+     *
+     * @param context       The context used to send the broadcast.
+     * @param transactionId The transaction id of the message in which the data was received. Valid transaction IDs are between (0,
+     *                      255).
+     * @throws IllegalArgumentException Thrown if an invalid transaction id is specified.
+     */
+    public static void sendAckToPebble(final Context context, final int transactionId)
+            throws IllegalArgumentException {
+
+        if ((transactionId & ~0xff) != 0) {
+            throw new IllegalArgumentException(String.format(
+                    "transaction id must be between (0, 255); got '%d'", transactionId));
+        }
+
+        final Intent ackIntent = new Intent(INTENT_APP_ACK);
+        ackIntent.putExtra(TRANSACTION_ID, transactionId);
+        context.sendBroadcast(ackIntent);
+    }
+
+    /**
+     * Send a message to the connected watch that the previously sent PebbleDictionary was not received successfully. To
+     * avoid protocol timeouts on the watch, applications <em>must</em> ACK or NACK all received messages.
+     *
+     * @param context       The context used to send the broadcast.
+     * @param transactionId The transaction id of the message in which the data was received. Valid transaction IDs are between (0,
+     *                      255).
+     * @throws IllegalArgumentException Thrown if an invalid transaction id is specified.
+     */
+    public static void sendNackToPebble(final Context context, final int transactionId)
+            throws IllegalArgumentException {
+
+        if ((transactionId & ~0xff) != 0) {
+            throw new IllegalArgumentException(String.format(
+                    "transaction id must be between (0, 255); got '%d'", transactionId));
+        }
+
+        final Intent nackIntent = new Intent(INTENT_APP_NACK);
+        nackIntent.putExtra(TRANSACTION_ID, transactionId);
+        context.sendBroadcast(nackIntent);
+    }
+
+    /**
+     * A convenience function to assist in programatically registering a broadcast receiver for the 'CONNECTED' intent.
+     * <p>
+     * To avoid leaking memory, activities registering BroadcastReceivers <em>must</em> unregister them in the
+     * Activity's {@link android.app.Activity#onPause()} method.
+     *
+     * @param context  The context in which to register the BroadcastReceiver.
+     * @param receiver The receiver to be registered.
+     * @return The registered receiver.
+     * @see Constants#INTENT_PEBBLE_CONNECTED
+     */
+    public static BroadcastReceiver registerPebbleConnectedReceiver(final Context context,
+                                                                    final BroadcastReceiver receiver) {
+        return registerBroadcastReceiverInternal(context, INTENT_PEBBLE_CONNECTED, receiver);
+    }
+
+    /**
+     * A convenience function to assist in programatically registering a broadcast receiver for the 'DISCONNECTED'
+     * intent.
+     * <p>
+     * Go avoid leaking memory, activities registering BroadcastReceivers <em>must</em> unregister them in the
+     * Activity's {@link android.app.Activity#onPause()} method.
+     *
+     * @param context  The context in which to register the BroadcastReceiver.
+     * @param receiver The receiver to be registered.
+     * @return The registered receiver.
+     * @see Constants#INTENT_PEBBLE_DISCONNECTED
+     */
+    public static BroadcastReceiver registerPebbleDisconnectedReceiver(final Context context,
+                                                                       final BroadcastReceiver receiver) {
+        return registerBroadcastReceiverInternal(context, INTENT_PEBBLE_DISCONNECTED, receiver);
+    }
+
+    /**
+     * A convenience function to assist in programatically registering a broadcast receiver for the 'RECEIVE' intent.
+     * <p>
+     * To avoid leaking memory, activities registering BroadcastReceivers <em>must</em> unregister them in the
+     * Activity's {@link android.app.Activity#onPause()} method.
+     *
+     * @param context  The context in which to register the BroadcastReceiver.
+     * @param receiver The receiver to be registered.
+     * @return The registered receiver.
+     * @see Constants#INTENT_APP_RECEIVE
+     */
+    public static BroadcastReceiver registerReceivedDataHandler(final Context context,
+                                                                final PebbleDataReceiver receiver) {
+        return registerBroadcastReceiverInternal(context, INTENT_APP_RECEIVE, receiver);
+    }
+
+
+    /**
+     * A convenience function to assist in programatically registering a broadcast receiver for the 'RECEIVE_ACK'
+     * intent.
+     * <p>
+     * To avoid leaking memory, activities registering BroadcastReceivers <em>must</em> unregister them in the
+     * Activity's {@link android.app.Activity#onPause()} method.
+     *
+     * @param context  The context in which to register the BroadcastReceiver.
+     * @param receiver The receiver to be registered.
+     * @return The registered receiver.
+     * @see Constants#INTENT_APP_RECEIVE_ACK
+     */
+    public static BroadcastReceiver registerReceivedAckHandler(final Context context,
+                                                               final PebbleAckReceiver receiver) {
+        return registerBroadcastReceiverInternal(context, INTENT_APP_RECEIVE_ACK, receiver);
+    }
+
+    /**
+     * A convenience function to assist in programatically registering a broadcast receiver for the 'RECEIVE_NACK'
+     * intent.
+     * <p>
+     * To avoid leaking memory, activities registering BroadcastReceivers <em>must</em> unregister them in the
+     * Activity's {@link android.app.Activity#onPause()} method.
+     *
+     * @param context  The context in which to register the BroadcastReceiver.
+     * @param receiver The receiver to be registered.
+     * @return The registered receiver.
+     * @see Constants#INTENT_APP_RECEIVE_NACK
+     */
+    public static BroadcastReceiver registerReceivedNackHandler(final Context context,
+                                                                final PebbleNackReceiver receiver) {
+        return registerBroadcastReceiverInternal(context, INTENT_APP_RECEIVE_NACK, receiver);
+    }
+
+    /**
+     * Register broadcast receiver internal.
+     *
+     * @param context  the context
+     * @param action   the action
+     * @param receiver the receiver
+     * @return the broadcast receiver
+     */
+    private static BroadcastReceiver registerBroadcastReceiverInternal(final Context context,
+                                                                       final String action, final BroadcastReceiver receiver) {
+        if (receiver == null) {
+            return null;
+        }
+
+        IntentFilter filter = new IntentFilter(action);
+        context.registerReceiver(receiver, filter);
+        return receiver;
+    }
+
+    /**
+     * A special-purpose BroadcastReceiver that makes it easy to handle 'RECEIVE' intents broadcast from pebble.apk.
+     */
+    public static abstract class PebbleDataReceiver extends BroadcastReceiver {
+
+        /**
+         * The subscribed uuid.
+         */
+        private final UUID subscribedUuid;
+
+        /**
+         * Instantiates a new pebble data receiver.
+         *
+         * @param subscribedUuid the subscribed uuid
+         */
+        protected PebbleDataReceiver(final UUID subscribedUuid) {
+            this.subscribedUuid = subscribedUuid;
+        }
+
+        /**
+         * Perform some work on the data received from the connected watch.
+         *
+         * @param context       The BroadcastReceiver's context.
+         * @param transactionId The transaction ID of the message in which the data was received. This is required when ACK/NACKing
+         *                      the received message.
+         * @param data          A dictionary of one-or-more key-value pairs received from the connected watch.
+         */
+        public abstract void receiveData(final Context context, final int transactionId,
+                                         final PebbleDictionary data);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onReceive(final Context context, final Intent intent) {
+            final UUID receivedUuid = (UUID) intent.getSerializableExtra(APP_UUID);
+
+            // Pebble-enabled apps are expected to be good citizens and only inspect broadcasts
+            // containing their UUID
+            if (!subscribedUuid.equals(receivedUuid)) {
+                return;
+            }
+
+            final int transactionId = intent.getIntExtra(TRANSACTION_ID, -1);
+            final String jsonData = intent.getStringExtra(MSG_DATA);
+            if (jsonData == null || jsonData.isEmpty()) {
+                return;
+            }
+
+            try {
+                final PebbleDictionary data = PebbleDictionary.fromJson(jsonData);
+                receiveData(context, transactionId, data);
+            } catch (JSONException e) {
+                e.printStackTrace();
+                return;
+            }
+        }
+    }
+
+    /**
+     * A special-purpose BroadcastReceiver that makes it easy to handle 'RECEIVE_ACK' intents broadcast from pebble
+     * .apk.
+     */
+    public static abstract class PebbleAckReceiver extends BroadcastReceiver {
+
+        /**
+         * The subscribed uuid.
+         */
+        private final UUID subscribedUuid;
+
+        /**
+         * Instantiates a new pebble ack receiver.
+         *
+         * @param subscribedUuid the subscribed uuid
+         */
+        protected PebbleAckReceiver(final UUID subscribedUuid) {
+            this.subscribedUuid = subscribedUuid;
+        }
+
+        /**
+         * Handle the ACK received from the connected watch.
+         *
+         * @param context       The BroadcastReceiver's context.
+         * @param transactionId The transaction ID of the message for which the ACK was received. This indicates which message was
+         *                      successfully received.
+         */
+        public abstract void receiveAck(final Context context, final int transactionId);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onReceive(final Context context, final Intent intent) {
+            final int transactionId = intent.getIntExtra(TRANSACTION_ID, -1);
+            receiveAck(context, transactionId);
+
+        }
+    }
+
+    /**
+     * A special-purpose BroadcastReceiver that makes it easy to handle 'RECEIVE_NACK' intents broadcast from pebble
+     * .apk.
+     */
+    public static abstract class PebbleNackReceiver extends BroadcastReceiver {
+
+        /**
+         * The subscribed uuid.
+         */
+        private final UUID subscribedUuid;
+
+        /**
+         * Instantiates a new pebble nack receiver.
+         *
+         * @param subscribedUuid the subscribed uuid
+         */
+        protected PebbleNackReceiver(final UUID subscribedUuid) {
+            this.subscribedUuid = subscribedUuid;
+        }
+
+        /**
+         * Handle the NACK received from the connected watch.
+         *
+         * @param context       The BroadcastReceiver's context.
+         * @param transactionId The transaction ID of the message for which the NACK was received. This indicates which message was
+         *                      not received.
+         */
+        public abstract void receiveNack(final Context context, final int transactionId);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onReceive(final Context context, final Intent intent) {
+            final int transactionId = intent.getIntExtra(TRANSACTION_ID, -1);
+            receiveNack(context, transactionId);
+
+        }
+    }
+
+    /**
+     * A special-purpose BroadcastReceiver that makes it easy to handle 'DATA_AVAILABLE' data logging intents broadcast from pebble.apk.
+     */
+    public static abstract class PebbleDataLogReceiver extends BroadcastReceiver {
+
+        /**
+         * The subscribed uuid.
+         */
+        private final UUID subscribedUuid;
+
+        /**
+         * The last data ID we've seen. Ignore subsequent intents for this same ID.
+         */
+        private int lastDataId;
+
+        /**
+         * Instantiates a new pebble nack receiver.
+         *
+         * @param subscribedUuid the subscribed uuid
+         */
+        protected PebbleDataLogReceiver(final UUID subscribedUuid) {
+            this.subscribedUuid = subscribedUuid;
+        }
+
+        /**
+         * Handle an UnsignedInteger data unit that was logged the watch and broadcast by pebble.apk.
+         *
+         * @param context   The BroadcastReceiver's context.
+         * @param logUuid   The UUID that uniquely identifies a data log.
+         * @param timestamp The timestamp when a data log was first created.
+         * @param tag       The user-defined tag for the corresponding data log.
+         * @param data      The unit of data that was logged on the watch.
+         * @throws UnsupportedOperationException Thrown if data is received and this handler is not implemented.
+         */
+        public void receiveData(final Context context, UUID logUuid,
+                                final Long timestamp, final Long tag,
+                                final Long data) {
+            throw new UnsupportedOperationException("UnsignedInteger handler not implemented");
+
+        }
+
+        /**
+         * Handle a byte array data unit that was logged the watch and broadcast by pebble.apk.
+         *
+         * @param context   The BroadcastReceiver's context.
+         * @param logUuid   The UUID that uniquely identifies a data log.
+         * @param timestamp The timestamp when a data log was first created.
+         * @param tag       The user-defined tag for the corresponding data log.
+         * @param data      The unit of data that was logged on the watch.
+         * @throws UnsupportedOperationException Thrown if data is received and this handler is not implemented.
+         */
+        public void receiveData(final Context context, UUID logUuid,
+                                final Long timestamp, final Long tag,
+                                final byte[] data) {
+            throw new UnsupportedOperationException("Byte array handler not implemented");
+        }
+
+        /**
+         * Handle an int data unit that was logged the watch and broadcast by pebble.apk.
+         *
+         * @param context   The BroadcastReceiver's context.
+         * @param logUuid   The UUID that uniquely identifies a data log.
+         * @param timestamp The timestamp when a data log was first created.
+         * @param tag       The user-defined tag for the corresponding data log.
+         * @param data      The unit of data that was logged on the watch.
+         * @throws UnsupportedOperationException Thrown if data is received and this handler is not implemented.
+         */
+        public void receiveData(final Context context, UUID logUuid,
+                                final Long timestamp, final Long tag, final int data) {
+            throw new UnsupportedOperationException("int handler not implemented");
+
+        }
+
+        /**
+         * Called when a session has been finished on the watch and all data has been transmitted by pebble.apk
+         *
+         * @param context   The BroadcastReceiver's context.
+         * @param logUuid   The UUID that uniquely identifies a data log.
+         * @param timestamp The timestamp when a data log was first created.
+         * @param tag       The user-defined tag for the corresponding data log.
+         */
+        public void onFinishSession(final Context context, UUID logUuid, final Long timestamp,
+                                    final Long tag) {
+            // Do nothing by default
+        }
+
+        private void handleReceiveDataIntent(final Context context, final Intent intent, final UUID logUuid,
+                                             final Long timestamp, final Long tag) {
+            final int dataId = intent.getIntExtra(PBL_DATA_ID, -1);
+            if (dataId < 0) throw new IllegalArgumentException();
+
+            Log.i("pebble", "DataID: " + dataId + " LastDataID: " + lastDataId);
+
+            if (dataId == lastDataId) {
+                // If we see the same dataId multiple times, just ignore it.
+                return;
+            }
+
+            final PebbleDataType type = PebbleDataType.fromByte(intent.getByteExtra(PBL_DATA_TYPE, PebbleDataType.INVALID.ord));
+            if (type == null) throw new IllegalArgumentException();
+
+            switch (type) {
+                case BYTES:
+                    byte[] bytes = Base64.decode(intent.getStringExtra(PBL_DATA_OBJECT), Base64.NO_WRAP);
+                    if (bytes == null) {
+                        throw new IllegalArgumentException();
+                    }
+
+                    receiveData(context, logUuid, timestamp, tag, bytes);
+                    break;
+                case UINT:
+                    Long uint = (Long) intent.getSerializableExtra(PBL_DATA_OBJECT);
+                    if (uint == null) {
+                        throw new IllegalArgumentException();
+                    }
+
+                    receiveData(context, logUuid, timestamp, tag, uint);
+                    break;
+                case INT:
+                    Integer i = (Integer) intent.getSerializableExtra(PBL_DATA_OBJECT);
+                    if (i == null) {
+                        throw new IllegalArgumentException();
+                    }
+
+                    receiveData(context, logUuid, timestamp, tag, i.intValue());
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid type:" + type.toString());
+            }
+
+            lastDataId = dataId;
+
+            final Intent ackIntent = new Intent(INTENT_DL_ACK_DATA);
+            ackIntent.putExtra(DATA_LOG_UUID, logUuid);
+            ackIntent.putExtra(PBL_DATA_ID, dataId);
+            context.sendBroadcast(ackIntent);
+        }
+
+        private void handleFinishSessionIntent(final Context context, final Intent intent, final UUID logUuid,
+                                               final Long timestamp, final Long tag) {
+            onFinishSession(context, logUuid, timestamp, tag);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onReceive(final Context context, final Intent intent) {
+            final UUID receivedUuid = (UUID) intent.getSerializableExtra(APP_UUID);
+            // Pebble-enabled apps are expected to be good citizens and only inspect broadcasts
+            // containing their UUID
+            if (!subscribedUuid.equals(receivedUuid)) {
+                return;
+            }
+
+            try {
+                final UUID logUuid;
+                final Long timestamp;
+                final Long tag;
+
+                logUuid = (UUID) intent.getSerializableExtra(DATA_LOG_UUID);
+                if (logUuid == null) throw new IllegalArgumentException();
+
+                timestamp = (Long) intent.getSerializableExtra(DATA_LOG_TIMESTAMP);
+                if (timestamp == null) throw new IllegalArgumentException();
+
+                tag = (Long) intent.getSerializableExtra(DATA_LOG_TAG);
+                if (tag == null) throw new IllegalArgumentException();
+
+                if (intent.getAction() == INTENT_DL_RECEIVE_DATA) {
+                    handleReceiveDataIntent(context, intent, logUuid, timestamp, tag);
+                } else if (intent.getAction() == INTENT_DL_FINISH_SESSION) {
+                    handleFinishSessionIntent(context, intent, logUuid, timestamp, tag);
+                }
+            } catch (IllegalArgumentException e) {
+                e.printStackTrace();
+                return;
+            }
+        }
+    }
+
+    /**
+     * A convenience function to assist in programatically registering a broadcast receiver for the 'DATA_AVAILABLE'
+     * intent.
+     * <p>
+     * To avoid leaking memory, activities registering BroadcastReceivers <em>must</em> unregister them in the
+     * Activity's {@link android.app.Activity#onPause()} method.
+     *
+     * @param context  The context in which to register the BroadcastReceiver.
+     * @param receiver The receiver to be registered.
+     * @return The registered receiver.
+     * @see Constants#INTENT_DL_RECEIVE_DATA
+     */
+    public static BroadcastReceiver registerDataLogReceiver(final Context context,
+                                                            final PebbleDataLogReceiver receiver) {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(INTENT_DL_RECEIVE_DATA);
+        filter.addAction(INTENT_DL_FINISH_SESSION);
+        context.registerReceiver(receiver, filter);
+
+        return receiver;
+    }
+
+    /**
+     * A convenience function to emit an intent to pebble.apk to request the data logs for a particular app. If data
+     * is available, pebble.apk will advertise the data via 'INTENT_DL_RECEIVE_DATA' intents.
+     * <p>
+     * To avoid leaking memory, activities registering BroadcastReceivers <em>must</em> unregister them in the
+     * Activity's {@link android.app.Activity#onPause()} method.
+     *
+     * @param context The context in which to register the BroadcastReceiver.
+     * @param appUuid The app for which to request data logs.
+     * @see Constants#INTENT_DL_RECEIVE_DATA
+     * @see Constants#INTENT_DL_REQUEST_DATA
+     */
+    public static void requestDataLogsForApp(final Context context, final UUID appUuid) {
+        final Intent requestIntent = new Intent(INTENT_DL_REQUEST_DATA);
+        requestIntent.putExtra(APP_UUID, appUuid);
+        context.sendBroadcast(requestIntent);
+    }
+
+    public static class FirmwareVersionInfo {
+        private final int major;
+        private final int minor;
+        private final int point;
+        private final String tag;
+
+        FirmwareVersionInfo(int major, int minor, int point, String tag) {
+            this.major = major;
+            this.minor = minor;
+            this.point = point;
+            this.tag = tag;
+        }
+
+        public final int getMajor() {
+            return major;
+        }
+
+        public final int getMinor() {
+            return minor;
+        }
+
+        public final int getPoint() {
+            return point;
+        }
+
+        public final String getTag() {
+            return tag;
+        }
+    }
+
+    /**
+     * Query the Pebble ContentProvider - utility method for various PebbleKit helper methods
+     * <p>
+     * This attempts first to query the Basalt app provider, then if that is non-existant or disconnected
+     * queries the primary (i.e. original) provider authority
+     */
+    private static Cursor queryProvider(final Context context) {
+        Cursor c = context.getContentResolver().query(Constants.URI_CONTENT_BASALT, null, null, null, null);
+        if (c != null) {
+            if (c.moveToFirst()) {
+                // If Basalt app is connected, talk to that (return the open cursor)
+                if (c.getInt(KIT_STATE_COLUMN_CONNECTED) == 1) {
+                    c.moveToPrevious();
+                    return c;
+                }
+            }
+            // Else close the cursor and try the primary authority
+            c.close();
+        }
+
+        c = context.getContentResolver().query(Constants.URI_CONTENT_PRIMARY, null, null, null, null);
+        // Do nothing with this cursor - the calling method will check it for whatever it is looking for
+        return c;
+    }
+}

--- a/android/app/src/main/java/com/getpebble/android/kit/util/PebbleDictionary.java
+++ b/android/app/src/main/java/com/getpebble/android/kit/util/PebbleDictionary.java
@@ -1,0 +1,342 @@
+package com.getpebble.android.kit.util;
+
+import android.util.Base64;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * A collection of key-value pairs of heterogeneous types. PebbleDictionaries are the primary structure used to exchange
+ * data between the phone and watch.
+ * <p>
+ * To accommodate the mixed-types contained within a PebbleDictionary, an internal JSON representation is used when
+ * exchanging the dictionary between Android processes.
+ *
+ * @author zulak@getpebble.com
+ */
+public class PebbleDictionary implements Iterable<PebbleTuple> {
+
+    private static final String KEY = "key";
+    private static final String TYPE = "type";
+    private static final String LENGTH = "length";
+    private static final String VALUE = "value";
+
+    protected final Map<Integer, PebbleTuple> tuples = new HashMap<Integer, PebbleTuple>();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterator<PebbleTuple> iterator() {
+        return tuples.values().iterator();
+    }
+
+    /**
+     * Returns the number of key-value pairs in this dictionary.
+     *
+     * @return the number of key-value pairs in this dictionary
+     */
+    public int size() {
+        return tuples.size();
+    }
+
+    /**
+     * Returns true if this dictionary contains a mapping for the specified key.
+     *
+     * @param key key whose presence in this dictionary is to be tested
+     * @return true if this dictionary contains a mapping for the specified key
+     */
+    public boolean contains(final int key) {
+        return tuples.containsKey(key);
+    }
+
+    /**
+     * Removes the mapping for a key from this map if it is present.
+     *
+     * @param key key to be removed from the dictionary
+     */
+    public void remove(final int key) {
+        tuples.remove(key);
+    }
+
+    /**
+     * Associate the specified byte array with the provided key in the dictionary. If another key-value pair with the
+     * same key is already present in the dictionary, it will be replaced.
+     *
+     * @param key   key with which the specified value is associated
+     * @param bytes value to be associated with the specified key
+     */
+    public void addBytes(int key, byte[] bytes) {
+        PebbleTuple t = PebbleTuple.create(key, PebbleTuple.TupleType.BYTES, PebbleTuple.Width.NONE, bytes);
+        addTuple(t);
+    }
+
+    /**
+     * Associate the specified String with the provided key in the dictionary. If another key-value pair with the same
+     * key is already present in the dictionary, it will be replaced.
+     *
+     * @param key   key with which the specified value is associated
+     * @param value value to be associated with the specified key
+     */
+    public void addString(int key, String value) {
+        PebbleTuple t =
+                PebbleTuple.create(key, PebbleTuple.TupleType.STRING, PebbleTuple.Width.NONE, value);
+        addTuple(t);
+    }
+
+    /**
+     * Associate the specified signed byte with the provided key in the dictionary. If another key-value pair with the
+     * same key is already present in the dictionary, it will be replaced.
+     *
+     * @param key key with which the specified value is associated
+     * @param b   value to be associated with the specified key
+     */
+    public void addInt8(final int key, final byte b) {
+        PebbleTuple t = PebbleTuple.create(key, PebbleTuple.TupleType.INT, PebbleTuple.Width.BYTE, b);
+        addTuple(t);
+    }
+
+    /**
+     * Associate the specified unsigned byte with the provided key in the dictionary. If another key-value pair with the
+     * same key is already present in the dictionary, it will be replaced.
+     *
+     * @param key key with which the specified value is associated
+     * @param b   value to be associated with the specified key
+     */
+    public void addUint8(final int key, final byte b) {
+        PebbleTuple t = PebbleTuple.create(key, PebbleTuple.TupleType.UINT, PebbleTuple.Width.BYTE, b);
+        addTuple(t);
+    }
+
+    /**
+     * Associate the specified signed short with the provided key in the dictionary. If another key-value pair with the
+     * same key is already present in the dictionary, it will be replaced.
+     *
+     * @param key key with which the specified value is associated
+     * @param s   value to be associated with the specified key
+     */
+    public void addInt16(final int key, final short s) {
+        PebbleTuple t = PebbleTuple.create(key, PebbleTuple.TupleType.INT, PebbleTuple.Width.SHORT, s);
+        addTuple(t);
+    }
+
+    /**
+     * Associate the specified unsigned short with the provided key in the dictionary. If another key-value pair with
+     * the same key is already present in the dictionary, it will be replaced.
+     *
+     * @param key key with which the specified value is associated
+     * @param s   value to be associated with the specified key
+     */
+    public void addUint16(final int key, final short s) {
+        PebbleTuple t = PebbleTuple.create(key, PebbleTuple.TupleType.UINT, PebbleTuple.Width.SHORT, s);
+        addTuple(t);
+    }
+
+    /**
+     * Associate the specified signed int with the provided key in the dictionary. If another key-value pair with the
+     * same key is already present in the dictionary, it will be replaced.
+     *
+     * @param key key with which the specified value is associated
+     * @param i   value to be associated with the specified key
+     */
+    public void addInt32(final int key, final int i) {
+        PebbleTuple t = PebbleTuple.create(key, PebbleTuple.TupleType.INT, PebbleTuple.Width.WORD, i);
+        addTuple(t);
+    }
+
+    /**
+     * Associate the specified unsigned int with the provided key in the dictionary. If another key-value pair with the
+     * same key is already present in the dictionary, it will be replaced.
+     *
+     * @param key key with which the specified value is associated
+     * @param i   value to be associated with the specified key
+     */
+    public void addUint32(final int key, final int i) {
+        PebbleTuple t = PebbleTuple.create(key, PebbleTuple.TupleType.UINT, PebbleTuple.Width.WORD, i);
+        addTuple(t);
+    }
+
+    private PebbleTuple getTuple(int key, PebbleTuple.TupleType type) {
+        if (!tuples.containsKey(key) || tuples.get(key) == null) {
+            return null;
+        }
+
+        PebbleTuple t = tuples.get(key);
+        if (t.type != type) {
+            throw new PebbleDictTypeException(key, type, t.type);
+        }
+        return t;
+    }
+
+    /**
+     * Returns the signed integer to which the specified key is mapped, or null if the key does not exist in this
+     * dictionary.
+     *
+     * @param key key whose associated value is to be returned
+     * @return value to which the specified key is mapped
+     */
+    public Long getInteger(int key) {
+        PebbleTuple tuple = getTuple(key, PebbleTuple.TupleType.INT);
+        if (tuple == null) {
+            return null;
+        }
+        return (Long) tuple.value;
+    }
+
+    /**
+     * Returns the unsigned integer as a long to which the specified key is mapped, or null if the key does not exist in this
+     * dictionary. We are using the Long type here so that we can remove the guava dependency. This is done so that we dont
+     * have incompatibility issues with the UnsignedInteger class from the Holo application, which uses a newer version of Guava.
+     *
+     * @param key key whose associated value is to be returned
+     * @return value to which the specified key is mapped
+     */
+    public Long getUnsignedIntegerAsLong(int key) {
+        PebbleTuple tuple = getTuple(key, PebbleTuple.TupleType.UINT);
+        if (tuple == null) {
+            return null;
+        }
+        return (Long) tuple.value;
+    }
+
+    /**
+     * Returns the byte array to which the specified key is mapped, or null if the key does not exist in this
+     * dictionary.
+     *
+     * @param key key whose associated value is to be returned
+     * @return value to which the specified key is mapped
+     */
+    public byte[] getBytes(int key) {
+        PebbleTuple tuple = getTuple(key, PebbleTuple.TupleType.BYTES);
+        if (tuple == null) {
+            return null;
+        }
+        return (byte[]) tuple.value;
+    }
+
+    /**
+     * Returns the string to which the specified key is mapped, or null if the key does not exist in this dictionary.
+     *
+     * @param key key whose associated value is to be returned
+     * @return value to which the specified key is mapped
+     */
+    public String getString(int key) {
+        PebbleTuple tuple = getTuple(key, PebbleTuple.TupleType.STRING);
+        if (tuple == null) {
+            return null;
+        }
+        return (String) tuple.value;
+    }
+
+    public void addTuple(PebbleTuple tuple) {
+        if (tuples.size() > 0xff) {
+            throw new TupleOverflowException();
+        }
+
+        tuples.put(tuple.key, tuple);
+    }
+
+    public static class PebbleDictTypeException extends RuntimeException {
+        public PebbleDictTypeException(long key, PebbleTuple.TupleType expected, PebbleTuple.TupleType actual) {
+            super(String.format(
+                    "Expected type '%s', but got '%s' for key 0x%08x", expected.name(), actual.name(), key));
+        }
+    }
+
+    public static class TupleOverflowException extends RuntimeException {
+        public TupleOverflowException() {
+            super("Too many tuples in dict");
+        }
+    }
+
+    /**
+     * Returns a JSON representation of this dictionary.
+     *
+     * @return a JSON representation of this dictionary
+     */
+    public String toJsonString() {
+        try {
+            JSONArray array = new JSONArray();
+            for (PebbleTuple t : tuples.values()) {
+                array.put(serializeTuple(t));
+            }
+            return array.toString();
+        } catch (JSONException je) {
+            je.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * Deserializes a JSON representation of a PebbleDictionary.
+     *
+     * @param jsonString the JSON representation to be deserialized
+     * @throws JSONException thrown if the specified JSON representation cannot be parsed
+     */
+    public static PebbleDictionary fromJson(String jsonString) throws JSONException {
+        PebbleDictionary d = new PebbleDictionary();
+
+        JSONArray elements = new JSONArray(jsonString);
+        for (int idx = 0; idx < elements.length(); ++idx) {
+            JSONObject o = elements.getJSONObject(idx);
+            final int key = o.getInt(KEY);
+            final PebbleTuple.TupleType type = PebbleTuple.TYPE_NAMES.get(o.getString(TYPE));
+            final PebbleTuple.Width width = PebbleTuple.WIDTH_MAP.get(o.getInt(LENGTH));
+
+            switch (type) {
+                case BYTES:
+                    byte[] bytes = Base64.decode(o.getString(VALUE), Base64.NO_WRAP);
+                    d.addBytes(key, bytes);
+                    break;
+                case STRING:
+                    d.addString(key, o.getString(VALUE));
+                    break;
+                case INT:
+                    if (width == PebbleTuple.Width.BYTE) {
+                        d.addInt8(key, (byte) o.getInt(VALUE));
+                    } else if (width == PebbleTuple.Width.SHORT) {
+                        d.addInt16(key, (short) o.getInt(VALUE));
+                    } else if (width == PebbleTuple.Width.WORD) {
+                        d.addInt32(key, o.getInt(VALUE));
+                    }
+                    break;
+                case UINT:
+                    if (width == PebbleTuple.Width.BYTE) {
+                        d.addUint8(key, (byte) o.getInt(VALUE));
+                    } else if (width == PebbleTuple.Width.SHORT) {
+                        d.addUint16(key, (short) o.getInt(VALUE));
+                    } else if (width == PebbleTuple.Width.WORD) {
+                        d.addUint32(key, o.getInt(VALUE));
+                    }
+                    break;
+            }
+        }
+
+        return d;
+    }
+
+    private static JSONObject serializeTuple(PebbleTuple t) throws JSONException {
+        JSONObject j = new JSONObject();
+        j.put(KEY, t.key);
+        j.put(TYPE, t.type.getName());
+        j.put(LENGTH, t.width.value);
+
+        switch (t.type) {
+            case BYTES:
+                j.put(VALUE, Base64.encodeToString((byte[]) t.value, Base64.NO_WRAP));
+                break;
+            case STRING:
+            case INT:
+            case UINT:
+                j.put(VALUE, t.value);
+                break;
+        }
+
+        return j;
+    }
+}

--- a/android/app/src/main/java/com/getpebble/android/kit/util/PebbleTuple.java
+++ b/android/app/src/main/java/com/getpebble/android/kit/util/PebbleTuple.java
@@ -1,0 +1,132 @@
+package com.getpebble.android.kit.util;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * A key-value pair stored in a {@link PebbleDictionary}.
+ *
+ * @author zulak@getpebble.com
+ */
+public class PebbleTuple {
+
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+
+    static final Map<String, TupleType> TYPE_NAMES = new HashMap<String, TupleType>();
+
+    static {
+        for (TupleType t : TupleType.values()) {
+            TYPE_NAMES.put(t.getName(), t);
+        }
+    }
+
+    static final Map<Integer, Width> WIDTH_MAP = new HashMap<Integer, Width>();
+
+    static {
+        for (Width w : Width.values()) {
+            WIDTH_MAP.put(w.value, w);
+        }
+    }
+
+    /**
+     * The integer key identifying the tuple.
+     */
+    public final int key;
+    /**
+     * The type of value contained in the tuple.
+     */
+    public final TupleType type;
+    /**
+     * The 'width' of the tuple's value; This value will always be 'NONE' for non-integer types.
+     */
+    public final Width width;
+    /**
+     * The length of the tuple's value in bytes.
+     */
+    public final int length;
+    /**
+     * The value being associated with the tuple's key.
+     */
+    public final Object value;
+
+    private PebbleTuple(final int key, final TupleType type, final Width width, final int length, final Object value) {
+        this.key = key;
+        this.type = type;
+        this.width = width;
+        this.length = length;
+        this.value = value;
+    }
+
+    public static PebbleTuple create(
+            final int key, final TupleType type, final Width width, final int value) {
+        return new PebbleTuple(key, type, width, width.value, Long.valueOf(value));
+    }
+
+    public static PebbleTuple create(
+            final int key, final TupleType type, final Width width, final Object value) {
+
+        int length = Integer.MAX_VALUE;
+        if (width != Width.NONE) {
+            length = width.value;
+        } else if (type == TupleType.BYTES) {
+            length = ((byte[]) value).length;
+        } else if (type == TupleType.STRING) {
+            length = ((String) value).getBytes(UTF8).length;
+        }
+
+        if (length > 0xffff) {
+            throw new ValueOverflowException();
+        }
+
+        return new PebbleTuple(key, type, width, length, value);
+    }
+
+    public static class ValueOverflowException extends RuntimeException {
+        public ValueOverflowException() {
+            super("Value exceeds tuple capacity");
+        }
+    }
+
+    public static enum Width {
+        NONE(0),
+        BYTE(1),
+        SHORT(2),
+        WORD(4);
+
+        public final int value;
+
+        private Width(final int width) {
+            value = width;
+        }
+
+        public static Width fromValue(int widthValue) {
+            for (Width width : values()) {
+                if (widthValue == width.value) {
+                    return width;
+                }
+            }
+
+            throw new IllegalArgumentException("Unknown width value: " + widthValue);
+        }
+    }
+
+    public static enum TupleType {
+        BYTES(0),
+        STRING(1),
+        UINT(2),
+        INT(3);
+
+        public final byte ord;
+
+        private TupleType(int ord) {
+            this.ord = (byte) ord;
+        }
+
+        public String getName() {
+            return name().toLowerCase(Locale.US);
+        }
+    }
+}
+

--- a/android/app/src/main/java/com/getpebble/android/kit/util/SportsState.java
+++ b/android/app/src/main/java/com/getpebble/android/kit/util/SportsState.java
@@ -1,0 +1,314 @@
+package com.getpebble.android.kit.util;
+
+import android.content.Context;
+
+import com.getpebble.android.kit.Constants;
+import com.getpebble.android.kit.PebbleKit;
+
+/**
+ * This container class includes new values of time, distance, and pace or speed. To send the values
+ * to the watch use `synchronize`. This class is mutable, so consumers can update the values and
+ * synchronize the same instance again. Modifying the values of this class will not send the values.
+ * The consumer needs to invoke `synchronize` every time the UI needs to be updated.
+ */
+public class SportsState {
+    private int timeInSec = 0;
+    private float distance = 0;
+    private Integer paceInSec = null;
+    private Double speed = null;
+    private Byte heartBPM = null;
+    private String customLabel = null;
+    private String customValue = null;
+    private SportsState previousState = null;
+
+    /**
+     * The current time in seconds.
+     *
+     * @return the current activity duration in seconds
+     */
+    public int getTimeInSec() {
+        return timeInSec;
+    }
+
+    /**
+     * Set the current time in seconds.
+     * <p>
+     * The possible range is currently limited from 0 to 35999,
+     * inclusive (9h 59min 59sec). Values larger or smaller than the limits will
+     * be transformed into the maximum or minimum, respectively.
+     * <p>
+     * It will be presented as a duration string in the UI. Hours, minutes and
+     * seconds will be separated by colons. The hours value will only appear if
+     * the value is more than 1 hour.
+     *
+     * @param timeInSec The current time to set, in seconds.
+     */
+    public void setTimeInSec(int timeInSec) {
+        this.timeInSec = Math.max(0, Math.min(timeInSec, 35999));
+    }
+
+    /**
+     * The current distance in kilometers or miles.
+     *
+     * @return the current distance
+     */
+    public float getDistance() {
+        return distance;
+    }
+
+    /**
+     * Set the current distance in kilometers or miles.
+     * <p>
+     * The possible range is currently limited from 0 to 99.9, inclusive. Values
+     * larger or smaller than the limits will be transformed into the maximum or
+     * minimum, respectively.
+     * <p>
+     * It will be presented as a decimal number in the UI. The decimal part will be
+     * rounded to one digit.
+     * <p>
+     * The unit of distance is dependent on the current unit setting.
+     *
+     * @param distance The current distance to set, in kilometers or miles.
+     */
+    public void setDistance(float distance) {
+        this.distance = Math.max(0, Math.min(distance, 99.9f));
+    }
+
+    /**
+     * The current pace in seconds per kilometer or seconds per mile.
+     *
+     * @return the current pace
+     */
+    public int getPaceInSec() {
+        if (this.paceInSec == null) {
+            return 0;
+        }
+        return paceInSec;
+    }
+
+    /**
+     * Set the current pace in seconds per kilometer or seconds per mile.
+     * <p>
+     * The possible range is currently limited from 0 to 3599,
+     * inclusive (59min 59sec). Values larger or smaller than the limits will be
+     * transformed into the maximum or minimum, respectively.
+     * <p>
+     * It will be presented as a duration string in the UI. Minutes and seconds will
+     * be separated by colons.
+     * <p>
+     * Currently pace and speed cannot be presented at the same time. Setting speed
+     * will discard the value set through pace.
+     *
+     * @param paceInSec The pace to set, in seconds per kilometer or seconds per mile.
+     */
+    public void setPaceInSec(int paceInSec) {
+        this.speed = null;
+        this.paceInSec = Math.max(0, Math.min(paceInSec, 3599));
+    }
+
+    /**
+     * The current speed in kilometers per hour or miles per hour.
+     *
+     * @return the current speed
+     */
+    public float getSpeed() {
+        if (this.speed == null) {
+            return 0;
+        }
+        return speed.floatValue();
+    }
+
+    /**
+     * Set the current speed in kilometers per hour or miles per hour.
+     * <p>
+     * The possible range is currently limited from 0 to 99.9, inclusive. Values
+     * larger or smaller than the limits will be transformed into the maximum or
+     * minimum, respectively.
+     * <p>
+     * It will be presented as a decimal number in the UI. The decimal part will be
+     * rounded to one digit.
+     * <p>
+     * Currently pace and speed cannot be presented at the same time. Setting pace
+     * will discard the value set through speed.
+     *
+     * @param speed The current speed to set, in kilometers per hour or miles per hour.
+     */
+    public void setSpeed(float speed) {
+        this.paceInSec = null;
+        this.speed = Math.max(0, Math.min(speed, 99.9));
+    }
+
+    /**
+     * The current heart rate in beats per minute.
+     * <p>
+     * If the heart rate has never been set before, this property will return zero.
+     *
+     * @return the current heart rate
+     */
+    public byte getHeartBPM() {
+        if (this.heartBPM == null) {
+            return 0;
+        }
+        return heartBPM;
+    }
+
+    /**
+     * Set the current heart rate in beats per minute.
+     * <p>
+     * Currently there is no way to stop sending heart rate values if one heart rate
+     * value was sent. The last value will be shown in the UI.
+     *
+     * @param heartBPM The current heart rate to set, in beats per minute.
+     */
+    public void setHeartBPM(byte heartBPM) {
+        this.heartBPM = heartBPM;
+    }
+
+    /**
+     * The custom label to show in the sports UI.
+     *
+     * @return the custom label
+     */
+    public String getCustomLabel() {
+        return customLabel;
+    }
+
+    /**
+     * Set the custom label to show in the sports UI.
+     * <p>
+     * The maximum number of characters is ~10, but this maximum is not enforced.
+     * The label will be sent in upper case to the watch.
+     * <p>
+     * To be sent, both customLabel and customValue have to be set to non-null values.
+     *
+     * @param customLabel The custom label to set.
+     */
+    public void setCustomLabel(String customLabel) {
+        if (customLabel == null) {
+            this.customLabel = "";
+        } else {
+            this.customLabel = customLabel.toUpperCase();
+        }
+    }
+
+    /**
+     * The custom value to show in the sports UI.
+     *
+     * @return the custom value
+     */
+    public String getCustomValue() {
+        return customValue;
+    }
+
+    /**
+     * Set the custom value to show in the sports UI.
+     * <p>
+     * The maximum number of characters is ~8, but the maximum is not enforced.
+     * <p>
+     * To be sent, both customValue and customLabel have to be set to non-null values.
+     *
+     * @param customValue The custom value to set.
+     */
+    public void setCustomValue(String customValue) {
+        if (customValue == null) {
+            this.customValue = "";
+        } else {
+            this.customValue = customValue;
+        }
+    }
+
+    /**
+     * Synchronizes the current state of the Sports App to the connected watch.
+     * <p>
+     * The method tries to send the minimal set of changes since the last time the
+     * method was used, to try to minimize communication with the watch.
+     *
+     * @param context The context used to send the broadcast.
+     */
+    public void synchronize(final Context context) {
+        SportsState previousState = this.previousState;
+        boolean firstMessage = false;
+        if (previousState == null) {
+            previousState = this.previousState = new SportsState();
+            firstMessage = true;
+        }
+
+        PebbleDictionary message = new PebbleDictionary();
+        if (getTimeInSec() != previousState.getTimeInSec() || firstMessage) {
+            previousState.setTimeInSec(getTimeInSec());
+            message.addString(Constants.SPORTS_TIME_KEY, convertSecondsToString(getTimeInSec()));
+        }
+        if (getDistance() != previousState.getDistance() || firstMessage) {
+            previousState.setDistance(getDistance());
+            message.addString(Constants.SPORTS_DISTANCE_KEY, convertDistanceToString(getDistance()));
+        }
+        if (this.paceInSec != null) {
+            message.addUint8(Constants.SPORTS_LABEL_KEY, (byte) Constants.SPORTS_DATA_PACE);
+            if (getPaceInSec() != previousState.getPaceInSec()) {
+                previousState.setPaceInSec(getPaceInSec());
+                message.addString(Constants.SPORTS_DATA_KEY, convertSecondsToString(getPaceInSec()));
+            }
+        }
+        if (this.speed != null) {
+            message.addUint8(Constants.SPORTS_LABEL_KEY, (byte) Constants.SPORTS_DATA_SPEED);
+            if (getSpeed() != previousState.getSpeed()) {
+                previousState.setSpeed(getSpeed());
+                message.addString(Constants.SPORTS_DATA_KEY, convertDistanceToString(getSpeed()));
+            }
+        }
+        if (this.heartBPM != null) {
+            if (getHeartBPM() != previousState.getHeartBPM()) {
+                previousState.setHeartBPM(getHeartBPM());
+                message.addUint8(Constants.SPORTS_HR_BPM_KEY, getHeartBPM());
+            }
+        }
+        if (getCustomLabel() != null && getCustomValue() != null) {
+            if (!getCustomLabel().equals(previousState.getCustomLabel())) {
+                previousState.setCustomLabel(getCustomLabel());
+                message.addString(Constants.SPORTS_CUSTOM_LABEL_KEY, getCustomLabel());
+            }
+            if (!getCustomValue().equals(previousState.getCustomValue())) {
+                previousState.setCustomValue(getCustomValue());
+                message.addString(Constants.SPORTS_CUSTOM_VALUE_KEY, getCustomValue());
+            }
+        }
+
+        PebbleKit.sendDataToPebble(context, Constants.SPORTS_UUID, message);
+    }
+
+    /**
+     * Creates a formatted time string from a total seconds value, formatted as
+     * "h:mm:ss".
+     * <p>
+     * For example, supplying the value 3930.0f seconds will return @"1:05:30".
+     *
+     * @param totalSeconds The number of seconds from which to create the time string.
+     * @return the formatted time as "h:mm:ss"
+     */
+    private static String convertSecondsToString(int totalSeconds) {
+        if (totalSeconds < 0) {
+            return null;
+        }
+        int hours = totalSeconds / 3600;
+        int remainder = totalSeconds - (hours * 3600);
+        int minutes = remainder / 60;
+        int seconds = remainder - (minutes * 60);
+        if (hours > 0) {
+            return String.format("%2d:%02d:%02d", hours, minutes, seconds);
+        } else {
+            return String.format("%02d:%02d", minutes, seconds);
+        }
+    }
+
+    /**
+     * Creates a formatted decimal string with one decimal number.
+     * <p>
+     * For example, supplying the value 13.42f will return @"13.4".
+     *
+     * @param distance The decimal number to format as a string.
+     * @return the formatted decimal number
+     */
+    private static String convertDistanceToString(float distance) {
+        return String.format("%.1f", distance);
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/WatchService.kt
@@ -23,7 +23,7 @@ import timber.log.Timber
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WatchService : LifecycleService() {
-    private lateinit var coroutineScope: CoroutineScope
+    lateinit var coroutineScope: CoroutineScope
 
     private val bluetoothAdapter: BluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
 
@@ -44,6 +44,11 @@ class WatchService : LifecycleService() {
         notificationService = injectionComponent.createNotificationService()
         protocolHandler = injectionComponent.createProtocolHandler()
         connectionLooper = injectionComponent.createConnectionLooper()
+
+        val serviceComponent = injectionComponent.createServiceSubcomponentFactory()
+                .create(this)
+
+        serviceComponent.createAppMessageHandler()
 
         super.onCreate()
 

--- a/android/app/src/main/kotlin/io/rebble/fossil/bridges/Notifications.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/bridges/Notifications.kt
@@ -1,7 +1,7 @@
 package io.rebble.fossil.bridges
 
 import io.rebble.fossil.pigeons.Pigeons
-import io.rebble.libpebblecommon.blobdb.PushNotification
+import io.rebble.libpebblecommon.packets.blobdb.PushNotification
 import io.rebble.libpebblecommon.services.notification.NotificationService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/AppComponent.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/AppComponent.kt
@@ -25,6 +25,7 @@ interface AppComponent {
     fun createPairedStorage(): PairedStorage
 
     fun createActivitySubcomponentFactory(): ActivitySubcomponent.Factory
+    fun createServiceSubcomponentFactory(): ServiceSubcomponent.Factory
 
     @Component.Factory
     interface Factory {

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/LibPebbleModule.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/LibPebbleModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import io.rebble.fossil.bluetooth.BlueCommon
 import io.rebble.libpebblecommon.ProtocolHandler
 import io.rebble.libpebblecommon.ProtocolHandlerImpl
+import io.rebble.libpebblecommon.services.app.AppRunStateService
 import io.rebble.libpebblecommon.services.appmessage.AppMessageService
 import io.rebble.libpebblecommon.services.blobdb.BlobDBService
 import io.rebble.libpebblecommon.services.notification.NotificationService
@@ -35,4 +36,10 @@ class LibPebbleModule {
     fun provideAppMessageService(
             protocolHandler: ProtocolHandler
     ) = AppMessageService(protocolHandler)
+
+    @Provides
+    @Singleton
+    fun provideAppRunStateService(
+            protocolHandler: ProtocolHandler
+    ) = AppRunStateService(protocolHandler)
 }

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/LibPebbleModule.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/LibPebbleModule.kt
@@ -2,10 +2,10 @@ package io.rebble.fossil.di
 
 import dagger.Module
 import dagger.Provides
-import dagger.Reusable
 import io.rebble.fossil.bluetooth.BlueCommon
 import io.rebble.libpebblecommon.ProtocolHandler
 import io.rebble.libpebblecommon.ProtocolHandlerImpl
+import io.rebble.libpebblecommon.services.appmessage.AppMessageService
 import io.rebble.libpebblecommon.services.blobdb.BlobDBService
 import io.rebble.libpebblecommon.services.notification.NotificationService
 import javax.inject.Singleton
@@ -25,8 +25,14 @@ class LibPebbleModule {
     ) = BlobDBService(protocolHandler)
 
     @Provides
-    @Reusable
+    @Singleton
     fun provideNotificationService(
             blobDBService: BlobDBService
     ) = NotificationService(blobDBService)
+
+    @Provides
+    @Singleton
+    fun provideAppMessageService(
+            protocolHandler: ProtocolHandler
+    ) = AppMessageService(protocolHandler)
 }

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/ServiceModule.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/ServiceModule.kt
@@ -1,0 +1,15 @@
+package io.rebble.fossil.di
+
+import androidx.lifecycle.lifecycleScope
+import dagger.Module
+import dagger.Provides
+import io.rebble.fossil.WatchService
+import kotlinx.coroutines.CoroutineScope
+
+@Module
+class ServiceModule {
+    @Provides
+    fun provideCoroutineScope(watchService: WatchService): CoroutineScope {
+        return watchService.lifecycleScope
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/di/ServiceSubcomponent.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/di/ServiceSubcomponent.kt
@@ -1,0 +1,25 @@
+package io.rebble.fossil.di
+
+import dagger.BindsInstance
+import dagger.Subcomponent
+import io.rebble.fossil.WatchService
+import io.rebble.fossil.handlers.AppMessageHandler
+import javax.inject.Scope
+
+@PerService
+@Subcomponent(
+        modules = [
+            ServiceModule::class
+        ]
+)
+interface ServiceSubcomponent {
+    fun createAppMessageHandler(): AppMessageHandler
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance watchService: WatchService): ServiceSubcomponent
+    }
+}
+
+@Scope
+annotation class PerService

--- a/android/app/src/main/kotlin/io/rebble/fossil/handlers/AppMessageHandler.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/handlers/AppMessageHandler.kt
@@ -1,0 +1,125 @@
+package io.rebble.fossil.handlers
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import com.getpebble.android.kit.Constants
+import com.getpebble.android.kit.util.PebbleDictionary
+import io.rebble.fossil.middleware.getPebbleDictionary
+import io.rebble.fossil.middleware.toPacket
+import io.rebble.fossil.util.coroutines.asFlow
+import io.rebble.libpebblecommon.packets.AppMessage
+import io.rebble.libpebblecommon.services.appmessage.AppMessageService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import java.util.*
+import javax.inject.Inject
+
+@OptIn(ExperimentalUnsignedTypes::class, ExperimentalStdlibApi::class)
+class AppMessageHandler @Inject constructor(
+        private val context: Context,
+        private val appMessageService: AppMessageService,
+        private val coroutineScope: CoroutineScope
+) {
+    init {
+        listenForIncomingPackets()
+
+        listenForOutgoingDataMessages()
+        listenForOutgoingAckMessages()
+        listenForOutgoingNackMessages()
+    }
+
+    private fun sendPushIntent(message: AppMessage.AppMessagePush) {
+        val intent = Intent(Constants.INTENT_APP_RECEIVE).apply {
+            putExtra(Constants.APP_UUID, message.uuid.get())
+            putExtra(Constants.TRANSACTION_ID, message.transactionId.get().toInt())
+
+            val dictionary = message.getPebbleDictionary()
+            putExtra(Constants.MSG_DATA, dictionary.toJsonString())
+        }
+        context.sendBroadcast(intent)
+    }
+
+    private fun sendAckIntent(message: AppMessage.AppMessageACK) {
+        val intent = Intent(Constants.INTENT_APP_RECEIVE_ACK).apply {
+            putExtra(Constants.TRANSACTION_ID, message.transactionId.get().toInt())
+        }
+
+        context.sendBroadcast(intent)
+    }
+
+    private fun sendNackIntent(message: AppMessage.AppMessageNACK) {
+        val intent = Intent(Constants.INTENT_APP_RECEIVE_NACK).apply {
+            putExtra(Constants.TRANSACTION_ID, message.transactionId.get().toInt())
+        }
+
+        context.sendBroadcast(intent)
+    }
+
+    private fun listenForIncomingPackets() {
+        coroutineScope.launch {
+            for (message in appMessageService.receivedMessages) {
+                when (message) {
+                    is AppMessage.AppMessagePush -> {
+                        sendPushIntent(message)
+                    }
+                    is AppMessage.AppMessageACK -> {
+                        sendAckIntent(message)
+                    }
+                    is AppMessage.AppMessageNACK -> {
+                        sendNackIntent(message)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun listenForOutgoingDataMessages() {
+        coroutineScope.launch {
+            IntentFilter(Constants.INTENT_APP_SEND).asFlow(context).collect { intent ->
+                val uuid = intent.getSerializableExtra(Constants.APP_UUID) as UUID
+                val dictionary: PebbleDictionary = PebbleDictionary.fromJson(
+                        intent.getStringExtra(Constants.MSG_DATA)
+                )
+                val transactionId: Int = intent.getIntExtra(Constants.TRANSACTION_ID, 0)
+
+                val packet = dictionary.toPacket(uuid, transactionId)
+
+                appMessageService.send(packet)
+            }
+
+        }
+    }
+
+    private fun listenForOutgoingAckMessages() {
+        coroutineScope.launch {
+            IntentFilter(Constants.INTENT_APP_ACK).asFlow(context).collect { intent ->
+
+                val transactionId: Int = intent.getIntExtra(Constants.TRANSACTION_ID, 0)
+
+                val packet = AppMessage.AppMessageACK(
+                        transactionId.toUByte()
+                )
+
+                appMessageService.send(packet)
+            }
+
+        }
+    }
+
+    private fun listenForOutgoingNackMessages() {
+
+        coroutineScope.launch {
+            IntentFilter(Constants.INTENT_APP_NACK).asFlow(context).collect { intent ->
+                val transactionId: Int = intent.getIntExtra(Constants.TRANSACTION_ID, 0)
+
+                val packet = AppMessage.AppMessageNACK(
+                        transactionId.toUByte()
+                )
+
+                appMessageService.send(packet)
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/middleware/PebbleDictionaryConverter.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/middleware/PebbleDictionaryConverter.kt
@@ -1,0 +1,98 @@
+package io.rebble.fossil.middleware
+
+import com.getpebble.android.kit.util.PebbleDictionary
+import com.getpebble.android.kit.util.PebbleTuple
+import io.rebble.libpebblecommon.packets.AppMessage
+import io.rebble.libpebblecommon.packets.AppMessageTuple
+import java.util.*
+
+@OptIn(ExperimentalUnsignedTypes::class)
+fun PebbleDictionary.toPacket(uuid: UUID, transactionId: Int): AppMessage.AppMessagePush {
+    val tuples = map { pebbleTuple ->
+        val key = pebbleTuple.key.toUInt()
+        val value = pebbleTuple.value
+        when (pebbleTuple.type) {
+            PebbleTuple.TupleType.BYTES -> {
+                AppMessageTuple.createUByteArray(
+                        key,
+                        (value as ByteArray).toUByteArray()
+                )
+            }
+            PebbleTuple.TupleType.STRING -> {
+                AppMessageTuple.createString(key, value as String)
+
+            }
+            PebbleTuple.TupleType.UINT -> {
+                when (pebbleTuple.width) {
+                    null, PebbleTuple.Width.NONE ->
+                        throw IllegalArgumentException("NONE width not supported")
+                    PebbleTuple.Width.BYTE ->
+                        AppMessageTuple.createUByte(key, (value as Long).toUByte())
+                    PebbleTuple.Width.SHORT ->
+                        AppMessageTuple.createUShort(key, (value as Long).toUShort())
+                    PebbleTuple.Width.WORD ->
+                        AppMessageTuple.createUInt(key, (value as Long).toUInt())
+                }
+
+            }
+            PebbleTuple.TupleType.INT -> {
+                when (pebbleTuple.width) {
+                    null, PebbleTuple.Width.NONE ->
+                        throw IllegalArgumentException("NONE width not supported")
+                    PebbleTuple.Width.BYTE ->
+                        AppMessageTuple.createByte(key, (value as Long).toByte())
+                    PebbleTuple.Width.SHORT ->
+                        AppMessageTuple.createShort(key, (value as Long).toShort())
+                    PebbleTuple.Width.WORD ->
+                        AppMessageTuple.createInt(key, (value as Long).toInt())
+                }
+            }
+            null -> throw IllegalArgumentException("Tuple type shouldn't be null")
+        }
+    }
+
+    return AppMessage.AppMessagePush(
+            transactionId.toUByte(),
+            uuid,
+            tuples
+    )
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+fun AppMessage.AppMessagePush.getPebbleDictionary(): PebbleDictionary {
+    val pebbleDictionary = PebbleDictionary()
+    for (item in this.dictionary.list) {
+        val intKey = item.key.get().toInt()
+        val size = item.dataLength.get().toInt()
+        when (AppMessageTuple.Type.fromValue(item.type.get())) {
+            AppMessageTuple.Type.ByteArray -> {
+                pebbleDictionary.addBytes(intKey, item.data.get().toByteArray())
+            }
+            AppMessageTuple.Type.CString -> {
+                pebbleDictionary.addString(intKey, item.dataAsString)
+            }
+            AppMessageTuple.Type.UInt -> {
+                pebbleDictionary.addTuple(
+                        PebbleTuple.create(
+                                intKey,
+                                PebbleTuple.TupleType.UINT,
+                                PebbleTuple.Width.fromValue(size),
+                                item.dataAsUnsignedNumber
+                        )
+                )
+            }
+            AppMessageTuple.Type.Int -> {
+                pebbleDictionary.addTuple(
+                        PebbleTuple.create(
+                                intKey,
+                                PebbleTuple.TupleType.INT,
+                                PebbleTuple.Width.fromValue(size),
+                                item.dataAsSignedNumber
+                        )
+                )
+            }
+        }
+    }
+
+    return pebbleDictionary
+}

--- a/android/app/src/main/kotlin/io/rebble/fossil/notifications/NotificationParser.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/notifications/NotificationParser.kt
@@ -4,7 +4,7 @@ import android.app.Notification
 import android.content.Context
 import android.provider.Telephony
 import android.service.notification.StatusBarNotification
-import io.rebble.libpebblecommon.blobdb.NotificationSource
+import io.rebble.libpebblecommon.packets.blobdb.NotificationSource
 
 fun StatusBarNotification.parseData(context: Context): ParsedNotification {
     val pm = context.packageManager

--- a/android/app/src/main/kotlin/io/rebble/fossil/notifications/ParsedNotification.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/notifications/ParsedNotification.kt
@@ -1,7 +1,8 @@
 package io.rebble.fossil.notifications
 
-import io.rebble.libpebblecommon.blobdb.NotificationSource
-import io.rebble.libpebblecommon.blobdb.PushNotification
+import io.rebble.libpebblecommon.packets.blobdb.NotificationSource
+import io.rebble.libpebblecommon.packets.blobdb.PushNotification
+
 
 data class ParsedNotification(
         val subject: String,

--- a/android/app/src/main/kotlin/io/rebble/fossil/providers/PebbleKitProvider.kt
+++ b/android/app/src/main/kotlin/io/rebble/fossil/providers/PebbleKitProvider.kt
@@ -1,0 +1,121 @@
+package io.rebble.fossil.providers
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import com.getpebble.android.kit.Constants
+import io.rebble.fossil.FossilApplication
+import io.rebble.fossil.bluetooth.ConnectionLooper
+import io.rebble.fossil.bluetooth.ConnectionState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PebbleKitProvider : ContentProvider() {
+    private var initialized = false
+
+    private lateinit var connectionLooper: ConnectionLooper
+
+    override fun onCreate(): Boolean {
+        // Do not initialize anything here as this gets called before Application.onCreate
+
+        return true
+    }
+
+    private fun initializeIfNeeded() {
+        if (initialized) {
+            return
+        }
+
+        val context = context
+                ?: throw IllegalStateException("Context should not be null when initializing")
+
+        initialized = true
+
+        val injectionComponent = (context as FossilApplication)
+                .component
+
+        connectionLooper = injectionComponent.createConnectionLooper()
+
+        GlobalScope.launch(Dispatchers.Main) {
+            connectionLooper.connectionState.collect {
+                context.contentResolver.notifyChange(Constants.URI_CONTENT_BASALT, null)
+            }
+        }
+    }
+
+    override fun query(uri: Uri, projection: Array<out String>?, selection: String?, selectionArgs: Array<out String>?, sortOrder: String?): Cursor? {
+        if (uri != Constants.URI_CONTENT_BASALT) {
+            return null
+        }
+
+        initializeIfNeeded()
+
+        val cursor = MatrixCursor(CURSOR_COLUMN_NAMES)
+
+        if (connectionLooper.connectionState.value is ConnectionState.Connected) {
+            // Hardcode latest 4.4.0 firmware for now until watch status packets are
+            // implemented
+
+            cursor.addRow(
+                    listOf(
+                            1, // Connected
+                            1, // App Message support
+                            0, // Data Logging support
+                            4, // Major version support
+                            4, // Minor version support
+                            0, // Point version support
+                            "", // Version Tag
+                    )
+            )
+        } else {
+            cursor.addRow(
+                    listOf(
+                            0, // Connected
+                            0, // App Message support
+                            0, // Data Logging support
+                            0, // Major version support
+                            0, // Minor version support
+                            0, // Point version support
+                            "", // Version Tag
+                    )
+            )
+        }
+
+        return cursor
+    }
+
+    override fun getType(uri: Uri): String? {
+        return null
+    }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? {
+        // This provider is read-only
+        return null
+    }
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int {
+        // This provider is read-only
+        return 0
+    }
+
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String>?): Int {
+        // This provider is read-only
+        return 0
+    }
+}
+
+private val CURSOR_COLUMN_NAMES = arrayOf(
+        Constants.KIT_STATE_COLUMN_CONNECTED.toString(),
+        Constants.KIT_STATE_COLUMN_APPMSG_SUPPORT.toString(),
+        Constants.KIT_STATE_COLUMN_DATALOGGING_SUPPORT.toString(),
+        Constants.KIT_STATE_COLUMN_VERSION_MAJOR.toString(),
+        Constants.KIT_STATE_COLUMN_VERSION_MINOR.toString(),
+        Constants.KIT_STATE_COLUMN_VERSION_POINT.toString(),
+        Constants.KIT_STATE_COLUMN_VERSION_TAG.toString()
+)

--- a/android/app/src/test/java/io/rebble/fossil/middleware/PebbleDictionaryConverterTest.kt
+++ b/android/app/src/test/java/io/rebble/fossil/middleware/PebbleDictionaryConverterTest.kt
@@ -1,0 +1,57 @@
+package io.rebble.fossil.middleware
+
+import io.rebble.libpebblecommon.packets.AppMessage
+import io.rebble.libpebblecommon.packets.AppMessageTuple
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.*
+
+@OptIn(ExperimentalUnsignedTypes::class)
+internal class PebbleDictionaryConverterTest {
+    @Test
+    fun convertToDictionaryAndBack() {
+        val testPushMessage = AppMessage.AppMessagePush(
+                5u,
+                UUID.fromString("30880933-cead-49f6-ba94-3a6f8cd3218a"),
+                listOf(
+                        AppMessageTuple.createUByteArray(77u, ubyteArrayOf(1u, 170u, 245u)),
+                        AppMessageTuple.createString(6710u, "Hello World"),
+                        AppMessageTuple.createString(7710u, "Emoji: \uD83D\uDC7D."),
+                        AppMessageTuple.createByte(38485u, -7),
+                        AppMessageTuple.createUByte(2130680u, 177u.toUByte()),
+                        AppMessageTuple.createShort(2845647u, -20),
+                        AppMessageTuple.createUShort(2845648u, 49885u.toUShort()),
+                        AppMessageTuple.createInt(2845649u, -707573),
+                        AppMessageTuple.createUInt(2845650u, 2448461u)
+                )
+        )
+
+        val dictionary = testPushMessage.getPebbleDictionary()
+        val newMessage = dictionary.toPacket(
+                UUID.fromString("30880933-cead-49f6-ba94-3a6f8cd3218a"),
+                5
+        )
+
+        val list = newMessage.dictionary.list.sortedBy { it.key.get() }
+
+
+        val expectedFirstArray = ubyteArrayOf(1u, 170u, 245u)
+        assertTrue("${expectedFirstArray.contentToString()} does not" +
+                " equal ${list[0].dataAsBytes.contentToString()}",
+                expectedFirstArray.contentEquals(list[0].dataAsBytes))
+        assertEquals("Hello World", list[1].dataAsString)
+        assertEquals("Emoji: \uD83D\uDC7D.", list[2].dataAsString)
+        assertEquals(-7, list[3].dataAsSignedNumber)
+        assertEquals(177, list[4].dataAsUnsignedNumber)
+        assertEquals(-20, list[5].dataAsSignedNumber)
+        assertEquals(49885, list[6].dataAsUnsignedNumber)
+        assertEquals(-707573, list[7].dataAsSignedNumber)
+        assertEquals(2448461, list[8].dataAsUnsignedNumber)
+
+        assertEquals(UUID.fromString("30880933-cead-49f6-ba94-3a6f8cd3218a"),
+                testPushMessage.uuid.get())
+        assertEquals(5,
+                testPushMessage.transactionId.valueNumber)
+    }
+}


### PR DESCRIPTION
I know it might seem a bit premature, but hang on with me: I think I'm in a pretty unique position here: 90% of my Pebble usage is through PebbleKit. I'm not using most of the 1st party features. That means that with this PR merged, I can switch to using Fossil full time, which means I will able to test it more and catch more issues.

PR includes modified copy of the https://github.com/pebble/pebble-android-sdk. If you think this is not okay, I can remove it and write my own version from scratch.

This PR depends on https://github.com/crc-32/libpebblecommon/pull/6