### PR TITLE
launch-qemu.sh: support for mac

### DIFF
--- a/scripts/launch-qemu.sh
+++ b/scripts/launch-qemu.sh
@@ -2,7 +2,7 @@
 
 if [[ "$PEBBLE_SDK" == "" ]]; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    PEBBLE_SDK=${HOME}/Library/Application Support/Pebble\ SDK
+    PEBBLE_SDK="${HOME}/Library/Application Support/Pebble SDK"
   else
     PEBBLE_SDK="$HOME/.pebble-sdk"
   fi
@@ -30,12 +30,15 @@ if [[ ! -f "$platform_spi" ]]; then
     exit 2
   fi
 fi
-platform_args="-pflash ${platform_micro} -machine ${platform_machine[$1]}"
+platform_args=(-pflash "$platform_micro")
+platform_args+=(-machine "${platform_machine[$1]}")
 if [[ "$1" == "aplite" ]]; then
-  platform_args="${platform_args} -cpu cortex-m3 -mtdblock ${platform_spi}"
+  platform_args+=(-cpu cortex-m3)
+  platform_args+=(-mtdblock "$platform_spi")
 else
-  platform_args="${platform_args} -cpu cortex-m4 -pflash ${platform_spi}"
+  platform_args+=(-cpu cortex-m4)
+  platform_args+=(-pflash "$platform_spi")
 fi
 
 # shellcheck disable=SC2086
-qemu-pebble -rtc base=localtime -serial null -serial tcp::${qemu_port},server,nowait -serial null $platform_args
+qemu-pebble -rtc base=localtime -serial null -serial tcp::${qemu_port},server,nowait -serial null "${platform_args[@]}"

--- a/scripts/launch-qemu.sh
+++ b/scripts/launch-qemu.sh
@@ -20,7 +20,12 @@ fi
 
 platform_micro="${PEBBLE_SDK}/SDKs/current/sdk-core/pebble/$1/qemu/qemu_micro_flash.bin"
 platform_spi="${PEBBLE_SDK}/SDKs/current/sdk-core/pebble/$1/qemu/qemu_spi_flash.bin"
-declare -A platform_machine=( [aplite]=pebble-bb2 [basalt]=pebble-snowy-bb [chalk]=pebble-s4-bb [diorite]=pebble-silk-bb [emery]=pebble-robert-bb )
+platform_machine__aplite=pebble-bb2
+platform_machine__basalt=pebble-snowy-bb
+platform_machine__chalk=pebble-s4-bb
+platform_machine__diorite=pebble-silk-bb
+platform_machine__emery=pebble-robert-bb
+platform_machine=platform_machine__$1
 qemu_port=8080
 
 if [[ ! -f "$platform_spi" ]]; then
@@ -31,7 +36,7 @@ if [[ ! -f "$platform_spi" ]]; then
   fi
 fi
 platform_args=(-pflash "$platform_micro")
-platform_args+=(-machine "${platform_machine[$1]}")
+platform_args+=(-machine ${!platform_machine})
 if [[ "$1" == "aplite" ]]; then
   platform_args+=(-cpu cortex-m3)
   platform_args+=(-mtdblock "$platform_spi")


### PR DESCRIPTION
Here are the changes I had to make to get this script working on a mac. The first commit fixes the issue of the space in the SDK path. The second commit makes the script work with bash 3, which is the version shipped with all macs (even latest versions). Bash 4 is available on macs via Homebrew, so the second commit is not necessary if we require users to install that.