### PR TITLE
emit empty device list after classic BT scan is complete

### DIFF
--- a/android/app/src/main/kotlin/io/rebble/cobble/bluetooth/scan/ClassicScanner.kt
+++ b/android/app/src/main/kotlin/io/rebble/cobble/bluetooth/scan/ClassicScanner.kt
@@ -62,12 +62,15 @@ class ClassicScanner @Inject constructor(private val context: Context) {
                         }
                         scanningFinishChannel.onReceive {
                             keepScanning = false
+                            emit(deviceList)
                         }
                         stopTrigger.onAwait {
                             keepScanning = false
+                            emit(deviceList)
                         }
                         onTimeout(scanEndTime - System.currentTimeMillis()) {
                             keepScanning = false
+                            emit(deviceList)
                         }
                     }
                 }


### PR DESCRIPTION
This fixes a bug where scan would not emit any data after the scan is complete without any found watches.