### PR TITLE
#100 - Fix a bug where PairPage would use Page scaffold instead of Tab scaffold

### DIFF
--- a/lib/ui/home/tabs/watches_tab.dart
+++ b/lib/ui/home/tabs/watches_tab.dart
@@ -356,7 +356,7 @@ class MyWatchesTab extends HookWidget implements CobbleScreen {
                 .toList()),
       ]),
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => context.push(PairPage()),
+        onPressed: () => context.push(PairPage.fromTab()),
         label: Text('PAIR A WATCH'),
         icon: Icon(Icons.add),
       ),

--- a/lib/ui/setup/first_run_page.dart
+++ b/lib/ui/setup/first_run_page.dart
@@ -144,9 +144,7 @@ class _FirstRunPageState extends State<FirstRunPage> {
                     label: Icon(RebbleIcons.caret_right),
                     backgroundColor: Theme.of(context).primaryColor,
                     onPressed: () => context.push(
-                      PairPage(
-                        fromLanding: true,
-                      ),
+                      PairPage.fromLanding(),
                     ),
                   ),
                 ],

--- a/lib/ui/setup/pair_page.dart
+++ b/lib/ui/setup/pair_page.dart
@@ -9,6 +9,7 @@ import 'package:cobble/ui/common/icons/fonts/rebble_icons.dart';
 import 'package:cobble/ui/common/icons/watch_icon.dart';
 import 'package:cobble/ui/home/home_page.dart';
 import 'package:cobble/ui/router/cobble_navigator.dart';
+import 'package:cobble/ui/router/cobble_scaffold.dart';
 import 'package:cobble/ui/router/cobble_screen.dart';
 import 'package:cobble/ui/setup/more_setup.dart';
 import 'package:flutter/material.dart';
@@ -22,10 +23,26 @@ final ScanControl scanControl = ScanControl();
 class PairPage extends HookWidget implements CobbleScreen {
   final bool fromLanding;
 
-  const PairPage({
+  const PairPage._({
     Key key,
     this.fromLanding = false,
   }) : super(key: key);
+
+  factory PairPage.fromLanding({
+    Key key,
+  }) =>
+      PairPage._(
+        fromLanding: true,
+        key: key,
+      );
+
+  factory PairPage.fromTab({
+    Key key,
+  }) =>
+      PairPage._(
+        fromLanding: false,
+        key: key,
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -78,107 +95,113 @@ class PairPage extends HookWidget implements CobbleScreen {
       uiConnectionControl.connectToWatch(addressWrapper);
     };
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text("Pair a watch"),
-        leading: BackButton(),
-      ),
-      body: ListView(
-        children: [
-          if (scan.scanning)
-            Padding(
-              padding: EdgeInsets.all(16.0),
-              child: UnconstrainedBox(
-                child: CircularProgressIndicator(),
-              ),
+    final title = 'Pair a watch';
+    final body = ListView(
+      children: [
+        if (scan.scanning)
+          Padding(
+            padding: EdgeInsets.all(16.0),
+            child: UnconstrainedBox(
+              child: CircularProgressIndicator(),
             ),
-          ...scan.devices
-              .map(
-                (e) => InkWell(
-                  child: Container(
-                    child: Row(
-                      children: <Widget>[
-                        Container(
-                          child: Center(
-                            child: PebbleWatchIcon(
-                              PebbleWatchModel.values[e.color],
-                            ),
+          ),
+        ...scan.devices
+            .map(
+              (e) => InkWell(
+                child: Container(
+                  child: Row(
+                    children: <Widget>[
+                      Container(
+                        child: Center(
+                          child: PebbleWatchIcon(
+                            PebbleWatchModel.values[e.color],
                           ),
-                          width: 56,
-                          height: 56,
-                          decoration: BoxDecoration(
-                              color: Theme.of(context).dividerColor,
-                              shape: BoxShape.circle),
                         ),
-                        SizedBox(width: 16),
-                        Column(
-                          children: <Widget>[
-                            Text(
-                              e.name,
-                              style: TextStyle(fontSize: 16),
-                            ),
-                            SizedBox(height: 4),
-                            Text(
-                              e.address
-                                  .toRadixString(16)
-                                  .padLeft(6, '0')
-                                  .toUpperCase(),
-                            ),
-                            Wrap(
-                              spacing: 4,
-                              children: [
-                                if (e.runningPRF && !e.firstUse)
-                                  Chip(
-                                    backgroundColor: Colors.deepOrange,
-                                    label: Text("Recovery"),
-                                  ),
-                                if (e.firstUse)
-                                  Chip(
-                                    backgroundColor: Color(0xffd4af37),
-                                    label: Text("New!"),
-                                  ),
-                              ],
-                            ),
-                          ],
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                        ),
-                        Expanded(
-                          child: Container(width: 0.0, height: 0.0),
-                        ),
-                        Icon(RebbleIcons.caret_right,
-                            color: Theme.of(context).colorScheme.secondary),
-                      ],
-                    ),
-                    margin: EdgeInsets.all(16),
+                        width: 56,
+                        height: 56,
+                        decoration: BoxDecoration(
+                            color: Theme.of(context).dividerColor,
+                            shape: BoxShape.circle),
+                      ),
+                      SizedBox(width: 16),
+                      Column(
+                        children: <Widget>[
+                          Text(
+                            e.name,
+                            style: TextStyle(fontSize: 16),
+                          ),
+                          SizedBox(height: 4),
+                          Text(
+                            e.address
+                                .toRadixString(16)
+                                .padLeft(6, '0')
+                                .toUpperCase(),
+                          ),
+                          Wrap(
+                            spacing: 4,
+                            children: [
+                              if (e.runningPRF && !e.firstUse)
+                                Chip(
+                                  backgroundColor: Colors.deepOrange,
+                                  label: Text("Recovery"),
+                                ),
+                              if (e.firstUse)
+                                Chip(
+                                  backgroundColor: Color(0xffd4af37),
+                                  label: Text("New!"),
+                                ),
+                            ],
+                          ),
+                        ],
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                      ),
+                      Expanded(
+                        child: Container(width: 0.0, height: 0.0),
+                      ),
+                      Icon(RebbleIcons.caret_right,
+                          color: Theme.of(context).colorScheme.secondary),
+                    ],
                   ),
-                  onTap: () {
-                    _targetPebble(e);
-                  },
+                  margin: EdgeInsets.all(16),
                 ),
-              )
-              .toList(),
-          FlatButton(
-            child: Text("SEARCH AGAIN WITH BLE"),
-            padding: EdgeInsets.symmetric(horizontal: 32.0),
-            textColor: Theme.of(context).accentColor,
-            onPressed: _refreshDevicesBle,
-          ),
-          FlatButton(
-            child: Text("SEARCH AGAIN WITH BT CLASSIC"),
-            padding: EdgeInsets.symmetric(horizontal: 32.0),
-            textColor: Theme.of(context).accentColor,
-            onPressed: _refreshDevicesClassic,
-          ),
-          if (fromLanding)
-            FlatButton(
-              child: Text("SKIP"),
-              padding: EdgeInsets.symmetric(horizontal: 32.0),
-              onPressed: () => context.pushAndRemoveAllBelow(
-                HomePage(),
+                onTap: () {
+                  _targetPebble(e);
+                },
               ),
             )
-        ],
-      ),
+            .toList(),
+        FlatButton(
+          child: Text("SEARCH AGAIN WITH BLE"),
+          padding: EdgeInsets.symmetric(horizontal: 32.0),
+          textColor: Theme.of(context).accentColor,
+          onPressed: _refreshDevicesBle,
+        ),
+        FlatButton(
+          child: Text("SEARCH AGAIN WITH BT CLASSIC"),
+          padding: EdgeInsets.symmetric(horizontal: 32.0),
+          textColor: Theme.of(context).accentColor,
+          onPressed: _refreshDevicesClassic,
+        ),
+        if (fromLanding)
+          FlatButton(
+            child: Text("SKIP"),
+            padding: EdgeInsets.symmetric(horizontal: 32.0),
+            onPressed: () => context.pushAndRemoveAllBelow(
+              HomePage(),
+            ),
+          )
+      ],
     );
+
+    if (fromLanding)
+      return CobbleScaffold.page(
+        title: title,
+        child: body,
+      );
+    else
+      return CobbleScaffold.tab(
+        title: title,
+        child: body,
+      );
   }
 }

--- a/test/domain/setup/pair_page_test.dart
+++ b/test/domain/setup/pair_page_test.dart
@@ -62,9 +62,7 @@ Widget wrapper(
       ],
       child: MaterialApp(
         navigatorObservers: [if (navigatorObserver != null) navigatorObserver],
-        home: PairPage(
-          fromLanding: true,
-        ),
+        home: PairPage.fromLanding(),
         routes: {
           '/moresetup': (_) => Container(),
         },


### PR DESCRIPTION
If screen is displayed inside tabbed view it needs to use CobbleScaffold.tab, otherwise it needs to use CobbleScaffold.page.

Resolves #100.