### PR TITLE
only load explicit ndk path if there is environment variable present

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,7 +27,9 @@ apply plugin: 'kotlin-kapt'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    ndkPath "$System.env.ANDROID_NDK_HOME"
+    if (System.getenv("ANDROID_NDK_HOME") != null) {
+        ndkPath "$System.env.ANDROID_NDK_HOME"
+    }
     compileSdkVersion 30
 
     sourceSets {


### PR DESCRIPTION
@AliceGrey What do you think of this workaround?

This should only load the ndkPath when environment variable is present. That way we do not annoy any developers in the Android Studio and Github Action still works.