### PR TITLE
Search again on pair page should clear previously scanned watches

### DIFF
--- a/lib/ui/setup/pair_page.dart
+++ b/lib/ui/setup/pair_page.dart
@@ -79,12 +79,14 @@ class PairPage extends HookWidget implements CobbleScreen {
 
     final _refreshDevicesBle = () {
       if (!scan.scanning) {
+        scan.devices.clear();
         scanControl.startBleScan();
       }
     };
 
     final _refreshDevicesClassic = () {
       if (!scan.scanning) {
+        scan.devices.clear();
         scanControl.startClassicScan();
       }
     };

--- a/lib/ui/setup/pair_page.dart
+++ b/lib/ui/setup/pair_page.dart
@@ -79,14 +79,14 @@ class PairPage extends HookWidget implements CobbleScreen {
 
     final _refreshDevicesBle = () {
       if (!scan.scanning) {
-        scan.devices.clear();
+        context.refresh(scanProvider).onScanStarted();
         scanControl.startBleScan();
       }
     };
 
     final _refreshDevicesClassic = () {
       if (!scan.scanning) {
-        scan.devices.clear();
+        context.refresh(scanProvider).onScanStarted();
         scanControl.startClassicScan();
       }
     };


### PR DESCRIPTION
Fixes #104

Another way we could do this is save the scanned watches to a temporary list and clear that so we're not clearing the provider. Not sure if there is any downside to just doing it this way though.