### PR TITLE
Gracefully handle null BluetoothAdapter

### DIFF
--- a/android/app/src/main/kotlin/io/rebble/cobble/bluetooth/BlueCommon.kt
+++ b/android/app/src/main/kotlin/io/rebble/cobble/bluetooth/BlueCommon.kt
@@ -21,7 +21,7 @@ class BlueCommon @Inject constructor(
         private val protocolHandler: ProtocolHandler,
         private val flutterPreferences: FlutterPreferences
 ) {
-    private val bluetoothAdapter: BluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+    private var bluetoothAdapter: BluetoothAdapter? = null
     private var driver: BlueIO? = null
 
     private var externalIncomingPacketHandler: (suspend (ByteArray) -> Unit)? = null
@@ -29,6 +29,9 @@ class BlueCommon @Inject constructor(
     fun startSingleWatchConnection(macAddress: String): Flow<SingleConnectionStatus> {
         bleScanner.stopScan()
         classicScanner.stopScan()
+
+        val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+        this@BlueCommon.bluetoothAdapter = bluetoothAdapter
 
         val bluetoothDevice = bluetoothAdapter.getRemoteDevice(macAddress)
 

--- a/android/app/src/main/kotlin/io/rebble/cobble/bluetooth/BlueCommon.kt
+++ b/android/app/src/main/kotlin/io/rebble/cobble/bluetooth/BlueCommon.kt
@@ -21,7 +21,6 @@ class BlueCommon @Inject constructor(
         private val protocolHandler: ProtocolHandler,
         private val flutterPreferences: FlutterPreferences
 ) {
-    private var bluetoothAdapter: BluetoothAdapter? = null
     private var driver: BlueIO? = null
 
     private var externalIncomingPacketHandler: (suspend (ByteArray) -> Unit)? = null
@@ -31,8 +30,6 @@ class BlueCommon @Inject constructor(
         classicScanner.stopScan()
 
         val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
-        this@BlueCommon.bluetoothAdapter = bluetoothAdapter
-
         val bluetoothDevice = bluetoothAdapter.getRemoteDevice(macAddress)
 
         Timber.d("Found Pebble device $bluetoothDevice'")


### PR DESCRIPTION
If I open the app in emulator, `getDefaultAdapter` returns null. I'm not sure whether this is correct fix or not but if that's correct approach, I'd like to have it merged. I have to include this temp fix in each topic branch I'm working on anyway...

Also fixes #76, unless we wish to do more.