### PR TITLE
do not ever return null tag via PebbleKitProvider

### DIFF
--- a/android/app/src/main/kotlin/io/rebble/cobble/providers/PebbleKitProvider.kt
+++ b/android/app/src/main/kotlin/io/rebble/cobble/providers/PebbleKitProvider.kt
@@ -76,7 +76,7 @@ class PebbleKitProvider : ContentProvider() {
             val majorVersion = groupValues?.elementAtOrNull(1)?.toIntOrNull() ?: 0
             val minorVersion = groupValues?.elementAtOrNull(2)?.toIntOrNull() ?: 0
             val pointVersion = groupValues?.elementAtOrNull(3)?.toIntOrNull() ?: 0
-            val tag = groupValues?.elementAtOrNull(4)
+            val tag = groupValues?.elementAtOrNull(4) ?: ""
 
             cursor.addRow(
                     listOf(


### PR DESCRIPTION
it appears Pebble app never did that so we need to to keep doing this for backwards compatibility of all PebbleKit apps