### PR TITLE
#151 - Fix a bug where connecting to watch from pair page ...

### DIFF
--- a/lib/infrastructure/datasources/preferences.dart
+++ b/lib/infrastructure/datasources/preferences.dart
@@ -103,6 +103,15 @@ class Preferences {
     await _sharedPrefs.setBool("firstRun", true);
     _preferencesUpdateStream.add(this);
   }
+
+  bool wasSetupSuccessful() {
+    return _sharedPrefs.getBool("bootSetup") ?? false;
+  }
+
+  Future<void> setWasSetupSuccessful(bool value) async {
+    await _sharedPrefs.setBool("bootSetup", value);
+    _preferencesUpdateStream.add(this);
+  }
 }
 
 final preferencesProvider = FutureProvider<Preferences>((ref) async {
@@ -143,6 +152,10 @@ final notificationsMutedPackagesProvider = _createPreferenceProvider(
 /// ```
 final hasBeenConnectedProvider = _createPreferenceProvider(
   (preferences) => preferences.hasBeenConnected(),
+);
+
+final wasSetupSuccessfulProvider = _createPreferenceProvider(
+  (preferences) => preferences.wasSetupSuccessful(),
 );
 
 StreamProvider<T> _createPreferenceProvider<T>(

--- a/lib/infrastructure/datasources/preferences.dart
+++ b/lib/infrastructure/datasources/preferences.dart
@@ -93,6 +93,16 @@ class Preferences {
     await _sharedPrefs.setBool("APP_REORDER_PENDING", value);
     _preferencesUpdateStream.add(this);
   }
+
+  /// Is set to bool after user has connected to their first watch.
+  bool hasBeenConnected() {
+    return _sharedPrefs.containsKey("firstRun");
+  }
+
+  Future<void> setHasBeenConnected() async {
+    await _sharedPrefs.setBool("firstRun", true);
+    _preferencesUpdateStream.add(this);
+  }
 }
 
 final preferencesProvider = FutureProvider<Preferences>((ref) async {
@@ -118,6 +128,21 @@ final notificationToggleProvider = _createPreferenceProvider(
 
 final notificationsMutedPackagesProvider = _createPreferenceProvider(
   (preferences) => preferences.getNotificationsMutedPackages(),
+);
+
+/// ```dart
+/// final hasBeenConnected =
+///   useProvider(hasBeenConnectedProvider).data?.value ?? false;
+/// ```
+/// OR
+/// ```dart
+/// final hasBeenConnected = useProvider(hasBeenConnectedProvider.last);
+/// useEffect(() {
+///   hasBeenConnected.then((value) => /*...*/);
+/// }, []);
+/// ```
+final hasBeenConnectedProvider = _createPreferenceProvider(
+  (preferences) => preferences.hasBeenConnected(),
 );
 
 StreamProvider<T> _createPreferenceProvider<T>(

--- a/lib/ui/setup/boot/rebble_setup_fail.dart
+++ b/lib/ui/setup/boot/rebble_setup_fail.dart
@@ -1,13 +1,16 @@
+import 'package:cobble/infrastructure/datasources/preferences.dart';
 import 'package:cobble/ui/home/home_page.dart';
 import 'package:cobble/ui/router/cobble_navigator.dart';
 import 'package:cobble/ui/router/cobble_scaffold.dart';
 import 'package:cobble/ui/router/cobble_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class RebbleSetupFail extends StatelessWidget implements CobbleScreen {
+class RebbleSetupFail extends HookWidget implements CobbleScreen {
   @override
   Widget build(BuildContext context) {
+    final preferences = useProvider(preferencesProvider);
     return CobbleScaffold.page(
       title: "Activate Rebble services",
       child: Column(
@@ -21,12 +24,9 @@ class RebbleSetupFail extends StatelessWidget implements CobbleScreen {
         ],
       ),
       floatingActionButton: FloatingActionButton.extended(
-          onPressed: () {
-            SharedPreferences.getInstance().then((prefs) {
-              prefs.setBool("bootSetup", false);
-            }).then((_) {
-              context.pushAndRemoveAllBelow(HomePage());
-            });
+          onPressed: () async {
+            await preferences.data?.value.setWasSetupSuccessful(false);
+            context.pushAndRemoveAllBelow(HomePage());
           },
           label: Text("OKAY")),
     );

--- a/lib/ui/setup/boot/rebble_setup_fail.dart
+++ b/lib/ui/setup/boot/rebble_setup_fail.dart
@@ -22,14 +22,11 @@ class RebbleSetupFail extends StatelessWidget implements CobbleScreen {
       ),
       floatingActionButton: FloatingActionButton.extended(
           onPressed: () {
-            SharedPreferences.getInstance()
-                .then((value) => {
-                      value.setBool("firstRun", false),
-                      value.setBool("bootSetup", false)
-                    })
-                .then(
-                  (value) => context.pushAndRemoveAllBelow(HomePage()),
-                );
+            SharedPreferences.getInstance().then((prefs) {
+              prefs.setBool("bootSetup", false);
+            }).then((_) {
+              context.pushAndRemoveAllBelow(HomePage());
+            });
           },
           label: Text("OKAY")),
     );

--- a/lib/ui/setup/boot/rebble_setup_success.dart
+++ b/lib/ui/setup/boot/rebble_setup_success.dart
@@ -40,7 +40,7 @@ class RebbleSetupSuccess extends HookWidget implements CobbleScreen {
           onPressed: () {
             SharedPreferences.getInstance().then((prefs) async {
               await preferences.data?.value.setHasBeenConnected();
-              prefs.setBool("bootSetup", true);
+              await preferences.data?.value.setWasSetupSuccessful(true);
             }).then((_) {
               context.pushAndRemoveAllBelow(HomePage());
             });

--- a/lib/ui/setup/boot/rebble_setup_success.dart
+++ b/lib/ui/setup/boot/rebble_setup_success.dart
@@ -1,3 +1,4 @@
+import 'package:cobble/infrastructure/datasources/preferences.dart';
 import 'package:cobble/infrastructure/datasources/web_services.dart';
 import 'package:cobble/localization/localization.dart';
 import 'package:cobble/ui/home/home_page.dart';
@@ -5,16 +6,14 @@ import 'package:cobble/ui/router/cobble_navigator.dart';
 import 'package:cobble/ui/router/cobble_scaffold.dart';
 import 'package:cobble/ui/router/cobble_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class RebbleSetupSuccess extends StatefulWidget implements CobbleScreen {
-  @override
-  State<StatefulWidget> createState() => _RebbleSetupSuccessState();
-}
-
-class _RebbleSetupSuccessState extends State<RebbleSetupSuccess> {
+class RebbleSetupSuccess extends HookWidget implements CobbleScreen {
   @override
   Widget build(BuildContext context) {
+    final preferences = useProvider(preferencesProvider);
     return CobbleScaffold.page(
       title: tr.setup.success.title,
       child: Column(
@@ -39,12 +38,12 @@ class _RebbleSetupSuccessState extends State<RebbleSetupSuccess> {
       ),
       floatingActionButton: FloatingActionButton.extended(
           onPressed: () {
-            SharedPreferences.getInstance()
-                .then((value) => {
-                      value.setBool("firstRun", false),
-                      value.setBool("bootSetup", true)
-                    })
-                .then((value) => context.pushAndRemoveAllBelow(HomePage()));
+            SharedPreferences.getInstance().then((prefs) async {
+              await preferences.data?.value.setHasBeenConnected();
+              prefs.setBool("bootSetup", true);
+            }).then((_) {
+              context.pushAndRemoveAllBelow(HomePage());
+            });
           },
           label: Text(tr.setup.success.fab)),
     );

--- a/lib/ui/setup/pair_page.dart
+++ b/lib/ui/setup/pair_page.dart
@@ -4,6 +4,7 @@ import 'package:cobble/domain/connection/pair_provider.dart';
 import 'package:cobble/domain/connection/scan_provider.dart';
 import 'package:cobble/domain/entities/pebble_scan_device.dart';
 import 'package:cobble/infrastructure/datasources/paired_storage.dart';
+import 'package:cobble/infrastructure/datasources/preferences.dart';
 import 'package:cobble/infrastructure/pigeons/pigeons.g.dart';
 import 'package:cobble/localization/localization.dart';
 import 'package:cobble/ui/common/components/cobble_button.dart';
@@ -52,6 +53,7 @@ class PairPage extends HookWidget implements CobbleScreen {
     final pairedStorage = useProvider(pairedStorageProvider);
     final scan = useProvider(scanProvider.state);
     final pair = useProvider(pairProvider).data?.value;
+    final preferences = useProvider(preferencesProvider);
 
     useEffect(() {
       if (pair == null || scan.devices.isEmpty) return null;
@@ -98,6 +100,7 @@ class PairPage extends HookWidget implements CobbleScreen {
       NumberWrapper addressWrapper = NumberWrapper();
       addressWrapper.value = dev.address;
       uiConnectionControl.connectToWatch(addressWrapper);
+      preferences.data?.value.setHasBeenConnected();
     };
 
     final title = tr.pairPage.title;


### PR DESCRIPTION
... wouldn't be remembered and app would show setup screen at next launch.

Note to reviewers: 
* Is there any other screen where user's can connect to watch?
* Is there better file where I can put key of saved preference? I decided on existing `preferences.dart` but some other file might be better.