### PR TITLE
Make alerting_apps.dart screen easier to toggle apps

### DIFF
--- a/lib/ui/common/components/cobble_tile.dart
+++ b/lib/ui/common/components/cobble_tile.dart
@@ -197,7 +197,8 @@ class CobbleTile extends StatelessWidget {
     ImageProvider? leading,
     required String title,
     String? subtitle,
-    required Widget child,
+    required void Function(bool)? onChanged,
+    required bool enabled,
   }) =>
       CobbleTile._(
         key: key,
@@ -205,7 +206,11 @@ class CobbleTile extends StatelessWidget {
         leading: _leadingToWidget(leading, size: 48),
         title: title,
         subtitle: subtitle,
-        trailing: child,
+        trailing: Switch(
+          value: enabled,
+          onChanged: onChanged,
+        ),
+        onTap: () => onChanged!(!enabled),
       );
 
   @override

--- a/lib/ui/screens/alerting_apps.dart
+++ b/lib/ui/screens/alerting_apps.dart
@@ -104,22 +104,19 @@ class AlertingApps extends HookWidget implements CobbleScreen {
                               : tr.alertingApps.mutedToday(
                                   muted: random.nextInt(8).toString(),
                                 ),
-                          child: Switch(
-                            value: app.enabled,
-                            onChanged: (value) async {
-                              var mutedPkgList =
-                                  mutedPackages.data?.value ?? [];
-                              if (value) {
-                                mutedPkgList.removeWhere(
-                                    (element) => element == app.packageId);
-                              } else {
-                                print(app.packageId);
-                                mutedPkgList.add(app.packageId);
-                              }
-                              await preferences.data?.value
-                                  .setNotificationsMutedPackages(mutedPkgList);
-                            },
-                          ),
+                          enabled: app.enabled,
+                          onChanged: (value) async {
+                            var mutedPkgList = mutedPackages.data?.value ?? [];
+                            if (value) {
+                              mutedPkgList.removeWhere(
+                                  (element) => element == app.packageId);
+                            } else {
+                              print(app.packageId);
+                              mutedPkgList.add(app.packageId);
+                            }
+                            await preferences.data?.value
+                                .setNotificationsMutedPackages(mutedPkgList);
+                          },
                         ),
                       )
                       .toList(),


### PR DESCRIPTION
Having to target a tiny switch on each list item isn't very ergonomic;
right handed users have to scrunch their hands to be able to access them
and left handled users have to stretch their hands to be able to access them.

Making the entire list delegate toggleable fixes this.