### PR TITLE
Send UI -> Background messages directly via flutter (no native involved)

### DIFF
--- a/android/app/src/main/java/io/rebble/cobble/pigeons/Pigeons.java
+++ b/android/app/src/main/java/io/rebble/cobble/pigeons/Pigeons.java
@@ -3,124 +3,91 @@
 
 package io.rebble.cobble.pigeons;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-
 import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.StandardMessageCodec;
+import java.util.ArrayList;
+import java.util.HashMap;
 
-/**
- * Generated class from Pigeon.
- */
+/** Generated class from Pigeon. */
 @SuppressWarnings("unused")
 public class Pigeons {
 
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class StringWrapper {
-        private String value;
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class StringWrapper {
+    private String value;
+    public String getValue() { return value; }
+    public void setValue(String setterArg) { this.value = setterArg; }
 
-        public String getValue() {
-            return value;
-        }
-
-        public void setValue(String setterArg) {
-            this.value = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("value", value);
-            return toMapResult;
-        }
-
-        static StringWrapper fromMap(HashMap map) {
-            StringWrapper fromMapResult = new StringWrapper();
-            Object value = map.get("value");
-            fromMapResult.value = (String) value;
-            return fromMapResult;
-        }
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("value", value);
+      return toMapResult;
     }
-
-    /** Generated class from Pigeon that represents data sent in messages. */
-    public static class ListWrapper {
-        private ArrayList value;
-
-        public ArrayList getValue() {
-            return value;
-        }
-
-        public void setValue(ArrayList setterArg) {
-            this.value = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("value", value);
-            return toMapResult;
-        }
-
-        static ListWrapper fromMap(HashMap map) {
-            ListWrapper fromMapResult = new ListWrapper();
-            Object value = map.get("value");
-            fromMapResult.value = (ArrayList) value;
-            return fromMapResult;
-        }
+    static StringWrapper fromMap(HashMap map) {
+      StringWrapper fromMapResult = new StringWrapper();
+      Object value = map.get("value");
+      fromMapResult.value = (String)value;
+      return fromMapResult;
     }
+  }
 
-    /** Generated class from Pigeon that represents data sent in messages. */
-    public static class BooleanWrapper {
-        private Boolean value;
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class ListWrapper {
+    private ArrayList value;
+    public ArrayList getValue() { return value; }
+    public void setValue(ArrayList setterArg) { this.value = setterArg; }
 
-        public Boolean getValue() {
-            return value;
-        }
-
-        public void setValue(Boolean setterArg) {
-            this.value = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("value", value);
-            return toMapResult;
-        }
-
-        static BooleanWrapper fromMap(HashMap map) {
-            BooleanWrapper fromMapResult = new BooleanWrapper();
-            Object value = map.get("value");
-            fromMapResult.value = (Boolean) value;
-            return fromMapResult;
-        }
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("value", value);
+      return toMapResult;
     }
-
-    /** Generated class from Pigeon that represents data sent in messages. */
-    public static class NumberWrapper {
-        private Long value;
-
-        public Long getValue() {
-            return value;
-        }
-
-        public void setValue(Long setterArg) {
-            this.value = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("value", value);
-            return toMapResult;
-        }
-
-        static NumberWrapper fromMap(HashMap map) {
-            NumberWrapper fromMapResult = new NumberWrapper();
-            Object value = map.get("value");
-            fromMapResult.value = (value == null) ? null : ((value instanceof Integer) ? (Integer) value : (Long) value);
-            return fromMapResult;
-        }
+    static ListWrapper fromMap(HashMap map) {
+      ListWrapper fromMapResult = new ListWrapper();
+      Object value = map.get("value");
+      fromMapResult.value = (ArrayList)value;
+      return fromMapResult;
     }
+  }
+
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class BooleanWrapper {
+    private Boolean value;
+    public Boolean getValue() { return value; }
+    public void setValue(Boolean setterArg) { this.value = setterArg; }
+
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("value", value);
+      return toMapResult;
+    }
+    static BooleanWrapper fromMap(HashMap map) {
+      BooleanWrapper fromMapResult = new BooleanWrapper();
+      Object value = map.get("value");
+      fromMapResult.value = (Boolean)value;
+      return fromMapResult;
+    }
+  }
+
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class NumberWrapper {
+    private Long value;
+    public Long getValue() { return value; }
+    public void setValue(Long setterArg) { this.value = setterArg; }
+
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("value", value);
+      return toMapResult;
+    }
+    static NumberWrapper fromMap(HashMap map) {
+      NumberWrapper fromMapResult = new NumberWrapper();
+      Object value = map.get("value");
+      fromMapResult.value = (value == null) ? null : ((value instanceof Integer) ? (Integer)value : (Long)value);
+      return fromMapResult;
+    }
+  }
 
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class TimelinePinPigeon {
@@ -495,1609 +462,1199 @@ public class Pigeons {
     public void setIsUnfaithful(Boolean setterArg) { this.isUnfaithful = setterArg; }
 
     HashMap toMap() {
-        HashMap<String, Object> toMapResult = new HashMap<>();
-        toMapResult.put("name", name);
-        toMapResult.put("address", address);
-        toMapResult.put("runningFirmware", runningFirmware.toMap());
-        toMapResult.put("recoveryFirmware", recoveryFirmware.toMap());
-        toMapResult.put("model", model);
-        toMapResult.put("bootloaderTimestamp", bootloaderTimestamp);
-        toMapResult.put("board", board);
-        toMapResult.put("serial", serial);
-        toMapResult.put("language", language);
-        toMapResult.put("languageVersion", languageVersion);
-        toMapResult.put("isUnfaithful", isUnfaithful);
-        return toMapResult;
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("name", name);
+      toMapResult.put("address", address);
+      toMapResult.put("runningFirmware", runningFirmware.toMap());
+      toMapResult.put("recoveryFirmware", recoveryFirmware.toMap());
+      toMapResult.put("model", model);
+      toMapResult.put("bootloaderTimestamp", bootloaderTimestamp);
+      toMapResult.put("board", board);
+      toMapResult.put("serial", serial);
+      toMapResult.put("language", language);
+      toMapResult.put("languageVersion", languageVersion);
+      toMapResult.put("isUnfaithful", isUnfaithful);
+      return toMapResult;
     }
-
-      static PebbleDevicePigeon fromMap(HashMap map) {
-          PebbleDevicePigeon fromMapResult = new PebbleDevicePigeon();
-          Object name = map.get("name");
-          fromMapResult.name = (String) name;
-          Object address = map.get("address");
-          fromMapResult.address = (address == null) ? null : ((address instanceof Integer) ? (Integer) address : (Long) address);
-          Object runningFirmware = map.get("runningFirmware");
-          fromMapResult.runningFirmware = PebbleFirmwarePigeon.fromMap((HashMap) runningFirmware);
-          Object recoveryFirmware = map.get("recoveryFirmware");
-          fromMapResult.recoveryFirmware = PebbleFirmwarePigeon.fromMap((HashMap) recoveryFirmware);
-          Object model = map.get("model");
-          fromMapResult.model = (model == null) ? null : ((model instanceof Integer) ? (Integer) model : (Long) model);
-          Object bootloaderTimestamp = map.get("bootloaderTimestamp");
-          fromMapResult.bootloaderTimestamp = (bootloaderTimestamp == null) ? null : ((bootloaderTimestamp instanceof Integer) ? (Integer) bootloaderTimestamp : (Long) bootloaderTimestamp);
-          Object board = map.get("board");
-          fromMapResult.board = (String) board;
-          Object serial = map.get("serial");
-          fromMapResult.serial = (String) serial;
-          Object language = map.get("language");
-          fromMapResult.language = (String) language;
-          Object languageVersion = map.get("languageVersion");
-          fromMapResult.languageVersion = (languageVersion == null) ? null : ((languageVersion instanceof Integer) ? (Integer) languageVersion : (Long) languageVersion);
-          Object isUnfaithful = map.get("isUnfaithful");
-          fromMapResult.isUnfaithful = (Boolean) isUnfaithful;
-          return fromMapResult;
-      }
+    static PebbleDevicePigeon fromMap(HashMap map) {
+      PebbleDevicePigeon fromMapResult = new PebbleDevicePigeon();
+      Object name = map.get("name");
+      fromMapResult.name = (String)name;
+      Object address = map.get("address");
+      fromMapResult.address = (address == null) ? null : ((address instanceof Integer) ? (Integer)address : (Long)address);
+      Object runningFirmware = map.get("runningFirmware");
+      fromMapResult.runningFirmware = PebbleFirmwarePigeon.fromMap((HashMap)runningFirmware);
+      Object recoveryFirmware = map.get("recoveryFirmware");
+      fromMapResult.recoveryFirmware = PebbleFirmwarePigeon.fromMap((HashMap)recoveryFirmware);
+      Object model = map.get("model");
+      fromMapResult.model = (model == null) ? null : ((model instanceof Integer) ? (Integer)model : (Long)model);
+      Object bootloaderTimestamp = map.get("bootloaderTimestamp");
+      fromMapResult.bootloaderTimestamp = (bootloaderTimestamp == null) ? null : ((bootloaderTimestamp instanceof Integer) ? (Integer)bootloaderTimestamp : (Long)bootloaderTimestamp);
+      Object board = map.get("board");
+      fromMapResult.board = (String)board;
+      Object serial = map.get("serial");
+      fromMapResult.serial = (String)serial;
+      Object language = map.get("language");
+      fromMapResult.language = (String)language;
+      Object languageVersion = map.get("languageVersion");
+      fromMapResult.languageVersion = (languageVersion == null) ? null : ((languageVersion instanceof Integer) ? (Integer)languageVersion : (Long)languageVersion);
+      Object isUnfaithful = map.get("isUnfaithful");
+      fromMapResult.isUnfaithful = (Boolean)isUnfaithful;
+      return fromMapResult;
+    }
   }
 
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class PebbleFirmwarePigeon {
-        private Long timestamp;
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class PebbleFirmwarePigeon {
+    private Long timestamp;
+    public Long getTimestamp() { return timestamp; }
+    public void setTimestamp(Long setterArg) { this.timestamp = setterArg; }
 
-        public Long getTimestamp() {
-            return timestamp;
-        }
+    private String version;
+    public String getVersion() { return version; }
+    public void setVersion(String setterArg) { this.version = setterArg; }
 
-        public void setTimestamp(Long setterArg) {
-            this.timestamp = setterArg;
-        }
+    private String gitHash;
+    public String getGitHash() { return gitHash; }
+    public void setGitHash(String setterArg) { this.gitHash = setterArg; }
 
-        private String version;
+    private Boolean isRecovery;
+    public Boolean getIsRecovery() { return isRecovery; }
+    public void setIsRecovery(Boolean setterArg) { this.isRecovery = setterArg; }
 
-        public String getVersion() {
-            return version;
-        }
+    private Long hardwarePlatform;
+    public Long getHardwarePlatform() { return hardwarePlatform; }
+    public void setHardwarePlatform(Long setterArg) { this.hardwarePlatform = setterArg; }
 
-        public void setVersion(String setterArg) {
-            this.version = setterArg;
-        }
+    private Long metadataVersion;
+    public Long getMetadataVersion() { return metadataVersion; }
+    public void setMetadataVersion(Long setterArg) { this.metadataVersion = setterArg; }
 
-        private String gitHash;
-
-        public String getGitHash() {
-            return gitHash;
-        }
-
-        public void setGitHash(String setterArg) {
-            this.gitHash = setterArg;
-        }
-
-        private Boolean isRecovery;
-
-        public Boolean getIsRecovery() {
-            return isRecovery;
-        }
-
-        public void setIsRecovery(Boolean setterArg) {
-            this.isRecovery = setterArg;
-        }
-
-        private Long hardwarePlatform;
-
-        public Long getHardwarePlatform() {
-            return hardwarePlatform;
-        }
-
-        public void setHardwarePlatform(Long setterArg) {
-            this.hardwarePlatform = setterArg;
-        }
-
-        private Long metadataVersion;
-
-        public Long getMetadataVersion() {
-            return metadataVersion;
-        }
-
-        public void setMetadataVersion(Long setterArg) {
-            this.metadataVersion = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("timestamp", timestamp);
-            toMapResult.put("version", version);
-            toMapResult.put("gitHash", gitHash);
-            toMapResult.put("isRecovery", isRecovery);
-            toMapResult.put("hardwarePlatform", hardwarePlatform);
-            toMapResult.put("metadataVersion", metadataVersion);
-            return toMapResult;
-        }
-
-        static PebbleFirmwarePigeon fromMap(HashMap map) {
-            PebbleFirmwarePigeon fromMapResult = new PebbleFirmwarePigeon();
-            Object timestamp = map.get("timestamp");
-            fromMapResult.timestamp = (timestamp == null) ? null : ((timestamp instanceof Integer) ? (Integer) timestamp : (Long) timestamp);
-            Object version = map.get("version");
-            fromMapResult.version = (String) version;
-            Object gitHash = map.get("gitHash");
-            fromMapResult.gitHash = (String) gitHash;
-            Object isRecovery = map.get("isRecovery");
-            fromMapResult.isRecovery = (Boolean) isRecovery;
-            Object hardwarePlatform = map.get("hardwarePlatform");
-            fromMapResult.hardwarePlatform = (hardwarePlatform == null) ? null : ((hardwarePlatform instanceof Integer) ? (Integer) hardwarePlatform : (Long) hardwarePlatform);
-            Object metadataVersion = map.get("metadataVersion");
-            fromMapResult.metadataVersion = (metadataVersion == null) ? null : ((metadataVersion instanceof Integer) ? (Integer) metadataVersion : (Long) metadataVersion);
-            return fromMapResult;
-        }
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("timestamp", timestamp);
+      toMapResult.put("version", version);
+      toMapResult.put("gitHash", gitHash);
+      toMapResult.put("isRecovery", isRecovery);
+      toMapResult.put("hardwarePlatform", hardwarePlatform);
+      toMapResult.put("metadataVersion", metadataVersion);
+      return toMapResult;
     }
-
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class AppInstallStatus {
-        private Double progress;
-
-        public Double getProgress() {
-            return progress;
-        }
-
-        public void setProgress(Double setterArg) {
-            this.progress = setterArg;
-        }
-
-        private Boolean isInstalling;
-
-        public Boolean getIsInstalling() {
-            return isInstalling;
-        }
-
-        public void setIsInstalling(Boolean setterArg) {
-            this.isInstalling = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("progress", progress);
-            toMapResult.put("isInstalling", isInstalling);
-            return toMapResult;
-        }
-
-        static AppInstallStatus fromMap(HashMap map) {
-            AppInstallStatus fromMapResult = new AppInstallStatus();
-            Object progress = map.get("progress");
-            fromMapResult.progress = (Double) progress;
-            Object isInstalling = map.get("isInstalling");
-            fromMapResult.isInstalling = (Boolean) isInstalling;
-            return fromMapResult;
-        }
+    static PebbleFirmwarePigeon fromMap(HashMap map) {
+      PebbleFirmwarePigeon fromMapResult = new PebbleFirmwarePigeon();
+      Object timestamp = map.get("timestamp");
+      fromMapResult.timestamp = (timestamp == null) ? null : ((timestamp instanceof Integer) ? (Integer)timestamp : (Long)timestamp);
+      Object version = map.get("version");
+      fromMapResult.version = (String)version;
+      Object gitHash = map.get("gitHash");
+      fromMapResult.gitHash = (String)gitHash;
+      Object isRecovery = map.get("isRecovery");
+      fromMapResult.isRecovery = (Boolean)isRecovery;
+      Object hardwarePlatform = map.get("hardwarePlatform");
+      fromMapResult.hardwarePlatform = (hardwarePlatform == null) ? null : ((hardwarePlatform instanceof Integer) ? (Integer)hardwarePlatform : (Long)hardwarePlatform);
+      Object metadataVersion = map.get("metadataVersion");
+      fromMapResult.metadataVersion = (metadataVersion == null) ? null : ((metadataVersion instanceof Integer) ? (Integer)metadataVersion : (Long)metadataVersion);
+      return fromMapResult;
     }
+  }
 
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class AppLogEntry {
-        private String uuid;
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class AppInstallStatus {
+    private Double progress;
+    public Double getProgress() { return progress; }
+    public void setProgress(Double setterArg) { this.progress = setterArg; }
 
-        public String getUuid() {
-            return uuid;
-        }
+    private Boolean isInstalling;
+    public Boolean getIsInstalling() { return isInstalling; }
+    public void setIsInstalling(Boolean setterArg) { this.isInstalling = setterArg; }
 
-        public void setUuid(String setterArg) {
-            this.uuid = setterArg;
-        }
-
-        private Long timestamp;
-
-        public Long getTimestamp() {
-            return timestamp;
-        }
-
-        public void setTimestamp(Long setterArg) {
-            this.timestamp = setterArg;
-        }
-
-        private Long level;
-
-        public Long getLevel() {
-            return level;
-        }
-
-        public void setLevel(Long setterArg) {
-            this.level = setterArg;
-        }
-
-        private Long lineNumber;
-
-        public Long getLineNumber() {
-            return lineNumber;
-        }
-
-        public void setLineNumber(Long setterArg) {
-            this.lineNumber = setterArg;
-        }
-
-        private String filename;
-
-        public String getFilename() {
-            return filename;
-        }
-
-        public void setFilename(String setterArg) {
-            this.filename = setterArg;
-        }
-
-        private String message;
-
-        public String getMessage() {
-            return message;
-        }
-
-        public void setMessage(String setterArg) {
-            this.message = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("uuid", uuid);
-            toMapResult.put("timestamp", timestamp);
-            toMapResult.put("level", level);
-            toMapResult.put("lineNumber", lineNumber);
-            toMapResult.put("filename", filename);
-            toMapResult.put("message", message);
-            return toMapResult;
-        }
-
-        static AppLogEntry fromMap(HashMap map) {
-            AppLogEntry fromMapResult = new AppLogEntry();
-            Object uuid = map.get("uuid");
-            fromMapResult.uuid = (String) uuid;
-            Object timestamp = map.get("timestamp");
-            fromMapResult.timestamp = (timestamp == null) ? null : ((timestamp instanceof Integer) ? (Integer) timestamp : (Long) timestamp);
-            Object level = map.get("level");
-            fromMapResult.level = (level == null) ? null : ((level instanceof Integer) ? (Integer) level : (Long) level);
-            Object lineNumber = map.get("lineNumber");
-            fromMapResult.lineNumber = (lineNumber == null) ? null : ((lineNumber instanceof Integer) ? (Integer) lineNumber : (Long) lineNumber);
-            Object filename = map.get("filename");
-            fromMapResult.filename = (String) filename;
-            Object message = map.get("message");
-            fromMapResult.message = (String) message;
-            return fromMapResult;
-        }
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("progress", progress);
+      toMapResult.put("isInstalling", isInstalling);
+      return toMapResult;
     }
-
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class InstallData {
-        private String uri;
-
-        public String getUri() {
-            return uri;
-        }
-
-        public void setUri(String setterArg) {
-            this.uri = setterArg;
-        }
-
-        private PbwAppInfo appInfo;
-
-        public PbwAppInfo getAppInfo() {
-            return appInfo;
-        }
-
-        public void setAppInfo(PbwAppInfo setterArg) {
-            this.appInfo = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("uri", uri);
-            toMapResult.put("appInfo", appInfo.toMap());
-            return toMapResult;
-        }
-
-        static InstallData fromMap(HashMap map) {
-            InstallData fromMapResult = new InstallData();
-            Object uri = map.get("uri");
-            fromMapResult.uri = (String) uri;
-            Object appInfo = map.get("appInfo");
-            fromMapResult.appInfo = PbwAppInfo.fromMap((HashMap) appInfo);
-            return fromMapResult;
-        }
+    static AppInstallStatus fromMap(HashMap map) {
+      AppInstallStatus fromMapResult = new AppInstallStatus();
+      Object progress = map.get("progress");
+      fromMapResult.progress = (Double)progress;
+      Object isInstalling = map.get("isInstalling");
+      fromMapResult.isInstalling = (Boolean)isInstalling;
+      return fromMapResult;
     }
+  }
 
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class PbwAppInfo {
-        private Boolean isValid;
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class AppLogEntry {
+    private String uuid;
+    public String getUuid() { return uuid; }
+    public void setUuid(String setterArg) { this.uuid = setterArg; }
 
-        public Boolean getIsValid() {
-            return isValid;
-        }
+    private Long timestamp;
+    public Long getTimestamp() { return timestamp; }
+    public void setTimestamp(Long setterArg) { this.timestamp = setterArg; }
 
-        public void setIsValid(Boolean setterArg) {
-            this.isValid = setterArg;
-        }
+    private Long level;
+    public Long getLevel() { return level; }
+    public void setLevel(Long setterArg) { this.level = setterArg; }
 
-        private String uuid;
+    private Long lineNumber;
+    public Long getLineNumber() { return lineNumber; }
+    public void setLineNumber(Long setterArg) { this.lineNumber = setterArg; }
 
-        public String getUuid() {
-            return uuid;
-        }
+    private String filename;
+    public String getFilename() { return filename; }
+    public void setFilename(String setterArg) { this.filename = setterArg; }
 
-        public void setUuid(String setterArg) {
-            this.uuid = setterArg;
-        }
+    private String message;
+    public String getMessage() { return message; }
+    public void setMessage(String setterArg) { this.message = setterArg; }
 
-        private String shortName;
-
-        public String getShortName() {
-            return shortName;
-        }
-
-        public void setShortName(String setterArg) {
-            this.shortName = setterArg;
-        }
-
-        private String longName;
-
-        public String getLongName() {
-            return longName;
-        }
-
-        public void setLongName(String setterArg) {
-            this.longName = setterArg;
-        }
-
-        private String companyName;
-
-        public String getCompanyName() {
-            return companyName;
-        }
-
-        public void setCompanyName(String setterArg) {
-            this.companyName = setterArg;
-        }
-
-        private Long versionCode;
-
-        public Long getVersionCode() {
-            return versionCode;
-        }
-
-        public void setVersionCode(Long setterArg) {
-            this.versionCode = setterArg;
-        }
-
-        private String versionLabel;
-
-        public String getVersionLabel() {
-            return versionLabel;
-        }
-
-        public void setVersionLabel(String setterArg) {
-            this.versionLabel = setterArg;
-        }
-
-        private HashMap appKeys;
-
-        public HashMap getAppKeys() {
-            return appKeys;
-        }
-
-        public void setAppKeys(HashMap setterArg) {
-            this.appKeys = setterArg;
-        }
-
-        private ArrayList capabilities;
-
-        public ArrayList getCapabilities() {
-            return capabilities;
-        }
-
-        public void setCapabilities(ArrayList setterArg) {
-            this.capabilities = setterArg;
-        }
-
-        private ArrayList resources;
-
-        public ArrayList getResources() {
-            return resources;
-        }
-
-        public void setResources(ArrayList setterArg) {
-            this.resources = setterArg;
-        }
-
-        private String sdkVersion;
-
-        public String getSdkVersion() {
-            return sdkVersion;
-        }
-
-        public void setSdkVersion(String setterArg) {
-            this.sdkVersion = setterArg;
-        }
-
-        private ArrayList targetPlatforms;
-
-        public ArrayList getTargetPlatforms() {
-            return targetPlatforms;
-        }
-
-        public void setTargetPlatforms(ArrayList setterArg) {
-            this.targetPlatforms = setterArg;
-        }
-
-        private WatchappInfo watchapp;
-
-        public WatchappInfo getWatchapp() {
-            return watchapp;
-        }
-
-        public void setWatchapp(WatchappInfo setterArg) {
-            this.watchapp = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("isValid", isValid);
-            toMapResult.put("uuid", uuid);
-            toMapResult.put("shortName", shortName);
-            toMapResult.put("longName", longName);
-            toMapResult.put("companyName", companyName);
-            toMapResult.put("versionCode", versionCode);
-            toMapResult.put("versionLabel", versionLabel);
-            toMapResult.put("appKeys", appKeys);
-            toMapResult.put("capabilities", capabilities);
-            toMapResult.put("resources", resources);
-            toMapResult.put("sdkVersion", sdkVersion);
-            toMapResult.put("targetPlatforms", targetPlatforms);
-            toMapResult.put("watchapp", watchapp.toMap());
-            return toMapResult;
-        }
-
-        static PbwAppInfo fromMap(HashMap map) {
-            PbwAppInfo fromMapResult = new PbwAppInfo();
-            Object isValid = map.get("isValid");
-            fromMapResult.isValid = (Boolean) isValid;
-            Object uuid = map.get("uuid");
-            fromMapResult.uuid = (String) uuid;
-            Object shortName = map.get("shortName");
-            fromMapResult.shortName = (String) shortName;
-            Object longName = map.get("longName");
-            fromMapResult.longName = (String) longName;
-            Object companyName = map.get("companyName");
-            fromMapResult.companyName = (String) companyName;
-            Object versionCode = map.get("versionCode");
-            fromMapResult.versionCode = (versionCode == null) ? null : ((versionCode instanceof Integer) ? (Integer) versionCode : (Long) versionCode);
-            Object versionLabel = map.get("versionLabel");
-            fromMapResult.versionLabel = (String) versionLabel;
-            Object appKeys = map.get("appKeys");
-            fromMapResult.appKeys = (HashMap) appKeys;
-            Object capabilities = map.get("capabilities");
-            fromMapResult.capabilities = (ArrayList) capabilities;
-            Object resources = map.get("resources");
-            fromMapResult.resources = (ArrayList) resources;
-            Object sdkVersion = map.get("sdkVersion");
-            fromMapResult.sdkVersion = (String) sdkVersion;
-            Object targetPlatforms = map.get("targetPlatforms");
-            fromMapResult.targetPlatforms = (ArrayList) targetPlatforms;
-            Object watchapp = map.get("watchapp");
-            fromMapResult.watchapp = WatchappInfo.fromMap((HashMap) watchapp);
-            return fromMapResult;
-        }
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("uuid", uuid);
+      toMapResult.put("timestamp", timestamp);
+      toMapResult.put("level", level);
+      toMapResult.put("lineNumber", lineNumber);
+      toMapResult.put("filename", filename);
+      toMapResult.put("message", message);
+      return toMapResult;
     }
-
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class WatchappInfo {
-        private Boolean watchface;
-
-        public Boolean getWatchface() {
-            return watchface;
-        }
-
-        public void setWatchface(Boolean setterArg) {
-            this.watchface = setterArg;
-        }
-
-        private Boolean hiddenApp;
-
-        public Boolean getHiddenApp() {
-            return hiddenApp;
-        }
-
-        public void setHiddenApp(Boolean setterArg) {
-            this.hiddenApp = setterArg;
-        }
-
-        private Boolean onlyShownOnCommunication;
-
-        public Boolean getOnlyShownOnCommunication() {
-            return onlyShownOnCommunication;
-        }
-
-        public void setOnlyShownOnCommunication(Boolean setterArg) {
-            this.onlyShownOnCommunication = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("watchface", watchface);
-            toMapResult.put("hiddenApp", hiddenApp);
-            toMapResult.put("onlyShownOnCommunication", onlyShownOnCommunication);
-            return toMapResult;
-        }
-
-        static WatchappInfo fromMap(HashMap map) {
-            WatchappInfo fromMapResult = new WatchappInfo();
-            Object watchface = map.get("watchface");
-            fromMapResult.watchface = (Boolean) watchface;
-            Object hiddenApp = map.get("hiddenApp");
-            fromMapResult.hiddenApp = (Boolean) hiddenApp;
-            Object onlyShownOnCommunication = map.get("onlyShownOnCommunication");
-            fromMapResult.onlyShownOnCommunication = (Boolean) onlyShownOnCommunication;
-            return fromMapResult;
-        }
+    static AppLogEntry fromMap(HashMap map) {
+      AppLogEntry fromMapResult = new AppLogEntry();
+      Object uuid = map.get("uuid");
+      fromMapResult.uuid = (String)uuid;
+      Object timestamp = map.get("timestamp");
+      fromMapResult.timestamp = (timestamp == null) ? null : ((timestamp instanceof Integer) ? (Integer)timestamp : (Long)timestamp);
+      Object level = map.get("level");
+      fromMapResult.level = (level == null) ? null : ((level instanceof Integer) ? (Integer)level : (Long)level);
+      Object lineNumber = map.get("lineNumber");
+      fromMapResult.lineNumber = (lineNumber == null) ? null : ((lineNumber instanceof Integer) ? (Integer)lineNumber : (Long)lineNumber);
+      Object filename = map.get("filename");
+      fromMapResult.filename = (String)filename;
+      Object message = map.get("message");
+      fromMapResult.message = (String)message;
+      return fromMapResult;
     }
+  }
 
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class AppReorderRequest {
-        private String uuid;
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class InstallData {
+    private String uri;
+    public String getUri() { return uri; }
+    public void setUri(String setterArg) { this.uri = setterArg; }
 
-        public String getUuid() {
-            return uuid;
-        }
+    private PbwAppInfo appInfo;
+    public PbwAppInfo getAppInfo() { return appInfo; }
+    public void setAppInfo(PbwAppInfo setterArg) { this.appInfo = setterArg; }
 
-        public void setUuid(String setterArg) {
-            this.uuid = setterArg;
-        }
-
-        private Long newPosition;
-
-        public Long getNewPosition() {
-            return newPosition;
-        }
-
-        public void setNewPosition(Long setterArg) {
-            this.newPosition = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("uuid", uuid);
-            toMapResult.put("newPosition", newPosition);
-            return toMapResult;
-        }
-
-        static AppReorderRequest fromMap(HashMap map) {
-            AppReorderRequest fromMapResult = new AppReorderRequest();
-            Object uuid = map.get("uuid");
-            fromMapResult.uuid = (String) uuid;
-            Object newPosition = map.get("newPosition");
-            fromMapResult.newPosition = (newPosition == null) ? null : ((newPosition instanceof Integer) ? (Integer) newPosition : (Long) newPosition);
-            return fromMapResult;
-        }
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("uri", uri);
+      toMapResult.put("appInfo", appInfo.toMap());
+      return toMapResult;
     }
-
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class AppEntriesPigeon {
-        private ArrayList appName;
-
-        public ArrayList getAppName() {
-            return appName;
-        }
-
-        public void setAppName(ArrayList setterArg) {
-            this.appName = setterArg;
-        }
-
-        private ArrayList packageId;
-
-        public ArrayList getPackageId() {
-            return packageId;
-        }
-
-        public void setPackageId(ArrayList setterArg) {
-            this.packageId = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("appName", appName);
-            toMapResult.put("packageId", packageId);
-            return toMapResult;
-        }
-
-        static AppEntriesPigeon fromMap(HashMap map) {
-            AppEntriesPigeon fromMapResult = new AppEntriesPigeon();
-            Object appName = map.get("appName");
-            fromMapResult.appName = (ArrayList) appName;
-            Object packageId = map.get("packageId");
-            fromMapResult.packageId = (ArrayList) packageId;
-            return fromMapResult;
-        }
+    static InstallData fromMap(HashMap map) {
+      InstallData fromMapResult = new InstallData();
+      Object uri = map.get("uri");
+      fromMapResult.uri = (String)uri;
+      Object appInfo = map.get("appInfo");
+      fromMapResult.appInfo = PbwAppInfo.fromMap((HashMap)appInfo);
+      return fromMapResult;
     }
+  }
 
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class ScreenshotResult {
-        private Boolean success;
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class PbwAppInfo {
+    private Boolean isValid;
+    public Boolean getIsValid() { return isValid; }
+    public void setIsValid(Boolean setterArg) { this.isValid = setterArg; }
 
-        public Boolean getSuccess() {
-            return success;
-        }
+    private String uuid;
+    public String getUuid() { return uuid; }
+    public void setUuid(String setterArg) { this.uuid = setterArg; }
 
-        public void setSuccess(Boolean setterArg) {
-            this.success = setterArg;
-        }
+    private String shortName;
+    public String getShortName() { return shortName; }
+    public void setShortName(String setterArg) { this.shortName = setterArg; }
 
-        private String imagePath;
+    private String longName;
+    public String getLongName() { return longName; }
+    public void setLongName(String setterArg) { this.longName = setterArg; }
 
-        public String getImagePath() {
-            return imagePath;
-        }
+    private String companyName;
+    public String getCompanyName() { return companyName; }
+    public void setCompanyName(String setterArg) { this.companyName = setterArg; }
 
-        public void setImagePath(String setterArg) {
-            this.imagePath = setterArg;
-        }
+    private Long versionCode;
+    public Long getVersionCode() { return versionCode; }
+    public void setVersionCode(Long setterArg) { this.versionCode = setterArg; }
 
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("success", success);
-            toMapResult.put("imagePath", imagePath);
-            return toMapResult;
-        }
+    private String versionLabel;
+    public String getVersionLabel() { return versionLabel; }
+    public void setVersionLabel(String setterArg) { this.versionLabel = setterArg; }
 
-        static ScreenshotResult fromMap(HashMap map) {
-            ScreenshotResult fromMapResult = new ScreenshotResult();
-            Object success = map.get("success");
-            fromMapResult.success = (Boolean) success;
-            Object imagePath = map.get("imagePath");
-            fromMapResult.imagePath = (String) imagePath;
-            return fromMapResult;
-        }
+    private HashMap appKeys;
+    public HashMap getAppKeys() { return appKeys; }
+    public void setAppKeys(HashMap setterArg) { this.appKeys = setterArg; }
+
+    private ArrayList capabilities;
+    public ArrayList getCapabilities() { return capabilities; }
+    public void setCapabilities(ArrayList setterArg) { this.capabilities = setterArg; }
+
+    private ArrayList resources;
+    public ArrayList getResources() { return resources; }
+    public void setResources(ArrayList setterArg) { this.resources = setterArg; }
+
+    private String sdkVersion;
+    public String getSdkVersion() { return sdkVersion; }
+    public void setSdkVersion(String setterArg) { this.sdkVersion = setterArg; }
+
+    private ArrayList targetPlatforms;
+    public ArrayList getTargetPlatforms() { return targetPlatforms; }
+    public void setTargetPlatforms(ArrayList setterArg) { this.targetPlatforms = setterArg; }
+
+    private WatchappInfo watchapp;
+    public WatchappInfo getWatchapp() { return watchapp; }
+    public void setWatchapp(WatchappInfo setterArg) { this.watchapp = setterArg; }
+
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("isValid", isValid);
+      toMapResult.put("uuid", uuid);
+      toMapResult.put("shortName", shortName);
+      toMapResult.put("longName", longName);
+      toMapResult.put("companyName", companyName);
+      toMapResult.put("versionCode", versionCode);
+      toMapResult.put("versionLabel", versionLabel);
+      toMapResult.put("appKeys", appKeys);
+      toMapResult.put("capabilities", capabilities);
+      toMapResult.put("resources", resources);
+      toMapResult.put("sdkVersion", sdkVersion);
+      toMapResult.put("targetPlatforms", targetPlatforms);
+      toMapResult.put("watchapp", watchapp.toMap());
+      return toMapResult;
     }
-
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class NotifActionExecuteReq {
-        private String itemId;
-
-        public String getItemId() {
-            return itemId;
-        }
-
-        public void setItemId(String setterArg) {
-            this.itemId = setterArg;
-        }
-
-        private Long actionId;
-
-        public Long getActionId() {
-            return actionId;
-        }
-
-        public void setActionId(Long setterArg) {
-            this.actionId = setterArg;
-        }
-
-        private String responseText;
-
-        public String getResponseText() {
-            return responseText;
-        }
-
-        public void setResponseText(String setterArg) {
-            this.responseText = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("itemId", itemId);
-            toMapResult.put("actionId", actionId);
-            toMapResult.put("responseText", responseText);
-            return toMapResult;
-        }
-
-        static NotifActionExecuteReq fromMap(HashMap map) {
-            NotifActionExecuteReq fromMapResult = new NotifActionExecuteReq();
-            Object itemId = map.get("itemId");
-            fromMapResult.itemId = (String) itemId;
-            Object actionId = map.get("actionId");
-            fromMapResult.actionId = (actionId == null) ? null : ((actionId instanceof Integer) ? (Integer) actionId : (Long) actionId);
-            Object responseText = map.get("responseText");
-            fromMapResult.responseText = (String) responseText;
-            return fromMapResult;
-        }
+    static PbwAppInfo fromMap(HashMap map) {
+      PbwAppInfo fromMapResult = new PbwAppInfo();
+      Object isValid = map.get("isValid");
+      fromMapResult.isValid = (Boolean)isValid;
+      Object uuid = map.get("uuid");
+      fromMapResult.uuid = (String)uuid;
+      Object shortName = map.get("shortName");
+      fromMapResult.shortName = (String)shortName;
+      Object longName = map.get("longName");
+      fromMapResult.longName = (String)longName;
+      Object companyName = map.get("companyName");
+      fromMapResult.companyName = (String)companyName;
+      Object versionCode = map.get("versionCode");
+      fromMapResult.versionCode = (versionCode == null) ? null : ((versionCode instanceof Integer) ? (Integer)versionCode : (Long)versionCode);
+      Object versionLabel = map.get("versionLabel");
+      fromMapResult.versionLabel = (String)versionLabel;
+      Object appKeys = map.get("appKeys");
+      fromMapResult.appKeys = (HashMap)appKeys;
+      Object capabilities = map.get("capabilities");
+      fromMapResult.capabilities = (ArrayList)capabilities;
+      Object resources = map.get("resources");
+      fromMapResult.resources = (ArrayList)resources;
+      Object sdkVersion = map.get("sdkVersion");
+      fromMapResult.sdkVersion = (String)sdkVersion;
+      Object targetPlatforms = map.get("targetPlatforms");
+      fromMapResult.targetPlatforms = (ArrayList)targetPlatforms;
+      Object watchapp = map.get("watchapp");
+      fromMapResult.watchapp = WatchappInfo.fromMap((HashMap)watchapp);
+      return fromMapResult;
     }
+  }
 
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class ActionResponsePigeon {
-        private Boolean success;
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class WatchappInfo {
+    private Boolean watchface;
+    public Boolean getWatchface() { return watchface; }
+    public void setWatchface(Boolean setterArg) { this.watchface = setterArg; }
 
-        public Boolean getSuccess() {
-            return success;
-        }
+    private Boolean hiddenApp;
+    public Boolean getHiddenApp() { return hiddenApp; }
+    public void setHiddenApp(Boolean setterArg) { this.hiddenApp = setterArg; }
 
-        public void setSuccess(Boolean setterArg) {
-            this.success = setterArg;
-        }
+    private Boolean onlyShownOnCommunication;
+    public Boolean getOnlyShownOnCommunication() { return onlyShownOnCommunication; }
+    public void setOnlyShownOnCommunication(Boolean setterArg) { this.onlyShownOnCommunication = setterArg; }
 
-        private String attributesJson;
-
-        public String getAttributesJson() {
-            return attributesJson;
-        }
-
-        public void setAttributesJson(String setterArg) {
-            this.attributesJson = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("success", success);
-            toMapResult.put("attributesJson", attributesJson);
-            return toMapResult;
-        }
-
-        static ActionResponsePigeon fromMap(HashMap map) {
-            ActionResponsePigeon fromMapResult = new ActionResponsePigeon();
-            Object success = map.get("success");
-            fromMapResult.success = (Boolean) success;
-            Object attributesJson = map.get("attributesJson");
-            fromMapResult.attributesJson = (String) attributesJson;
-            return fromMapResult;
-        }
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("watchface", watchface);
+      toMapResult.put("hiddenApp", hiddenApp);
+      toMapResult.put("onlyShownOnCommunication", onlyShownOnCommunication);
+      return toMapResult;
     }
-
-    /**
-     * Generated class from Pigeon that represents data sent in messages.
-     */
-    public static class ActionTrigger {
-        private String itemId;
-
-        public String getItemId() {
-            return itemId;
-        }
-
-        public void setItemId(String setterArg) {
-            this.itemId = setterArg;
-        }
-
-        private Long actionId;
-
-        public Long getActionId() {
-            return actionId;
-        }
-
-        public void setActionId(Long setterArg) {
-            this.actionId = setterArg;
-        }
-
-        private String attributesJson;
-
-        public String getAttributesJson() {
-            return attributesJson;
-        }
-
-        public void setAttributesJson(String setterArg) {
-            this.attributesJson = setterArg;
-        }
-
-        HashMap toMap() {
-            HashMap<String, Object> toMapResult = new HashMap<>();
-            toMapResult.put("itemId", itemId);
-            toMapResult.put("actionId", actionId);
-            toMapResult.put("attributesJson", attributesJson);
-            return toMapResult;
-        }
-
-        static ActionTrigger fromMap(HashMap map) {
-            ActionTrigger fromMapResult = new ActionTrigger();
-            Object itemId = map.get("itemId");
-            fromMapResult.itemId = (String) itemId;
-            Object actionId = map.get("actionId");
-            fromMapResult.actionId = (actionId == null) ? null : ((actionId instanceof Integer) ? (Integer) actionId : (Long) actionId);
-            Object attributesJson = map.get("attributesJson");
-            fromMapResult.attributesJson = (String) attributesJson;
-            return fromMapResult;
-        }
+    static WatchappInfo fromMap(HashMap map) {
+      WatchappInfo fromMapResult = new WatchappInfo();
+      Object watchface = map.get("watchface");
+      fromMapResult.watchface = (Boolean)watchface;
+      Object hiddenApp = map.get("hiddenApp");
+      fromMapResult.hiddenApp = (Boolean)hiddenApp;
+      Object onlyShownOnCommunication = map.get("onlyShownOnCommunication");
+      fromMapResult.onlyShownOnCommunication = (Boolean)onlyShownOnCommunication;
+      return fromMapResult;
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface PigeonLogger {
-        void v(StringWrapper arg);
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class AppEntriesPigeon {
+    private ArrayList appName;
+    public ArrayList getAppName() { return appName; }
+    public void setAppName(ArrayList setterArg) { this.appName = setterArg; }
 
-        void d(StringWrapper arg);
+    private ArrayList packageId;
+    public ArrayList getPackageId() { return packageId; }
+    public void setPackageId(ArrayList setterArg) { this.packageId = setterArg; }
 
-        void i(StringWrapper arg);
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("appName", appName);
+      toMapResult.put("packageId", packageId);
+      return toMapResult;
+    }
+    static AppEntriesPigeon fromMap(HashMap map) {
+      AppEntriesPigeon fromMapResult = new AppEntriesPigeon();
+      Object appName = map.get("appName");
+      fromMapResult.appName = (ArrayList)appName;
+      Object packageId = map.get("packageId");
+      fromMapResult.packageId = (ArrayList)packageId;
+      return fromMapResult;
+    }
+  }
 
-        void w(StringWrapper arg);
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class ScreenshotResult {
+    private Boolean success;
+    public Boolean getSuccess() { return success; }
+    public void setSuccess(Boolean setterArg) { this.success = setterArg; }
 
-        void e(StringWrapper arg);
+    private String imagePath;
+    public String getImagePath() { return imagePath; }
+    public void setImagePath(String setterArg) { this.imagePath = setterArg; }
 
-        /**
-         * Sets up an instance of `PigeonLogger` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, PigeonLogger api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.v", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.v(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("success", success);
+      toMapResult.put("imagePath", imagePath);
+      return toMapResult;
+    }
+    static ScreenshotResult fromMap(HashMap map) {
+      ScreenshotResult fromMapResult = new ScreenshotResult();
+      Object success = map.get("success");
+      fromMapResult.success = (Boolean)success;
+      Object imagePath = map.get("imagePath");
+      fromMapResult.imagePath = (String)imagePath;
+      return fromMapResult;
+    }
+  }
+
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class NotifActionExecuteReq {
+    private String itemId;
+    public String getItemId() { return itemId; }
+    public void setItemId(String setterArg) { this.itemId = setterArg; }
+
+    private Long actionId;
+    public Long getActionId() { return actionId; }
+    public void setActionId(Long setterArg) { this.actionId = setterArg; }
+
+    private String responseText;
+    public String getResponseText() { return responseText; }
+    public void setResponseText(String setterArg) { this.responseText = setterArg; }
+
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("itemId", itemId);
+      toMapResult.put("actionId", actionId);
+      toMapResult.put("responseText", responseText);
+      return toMapResult;
+    }
+    static NotifActionExecuteReq fromMap(HashMap map) {
+      NotifActionExecuteReq fromMapResult = new NotifActionExecuteReq();
+      Object itemId = map.get("itemId");
+      fromMapResult.itemId = (String)itemId;
+      Object actionId = map.get("actionId");
+      fromMapResult.actionId = (actionId == null) ? null : ((actionId instanceof Integer) ? (Integer)actionId : (Long)actionId);
+      Object responseText = map.get("responseText");
+      fromMapResult.responseText = (String)responseText;
+      return fromMapResult;
+    }
+  }
+
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class ActionResponsePigeon {
+    private Boolean success;
+    public Boolean getSuccess() { return success; }
+    public void setSuccess(Boolean setterArg) { this.success = setterArg; }
+
+    private String attributesJson;
+    public String getAttributesJson() { return attributesJson; }
+    public void setAttributesJson(String setterArg) { this.attributesJson = setterArg; }
+
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("success", success);
+      toMapResult.put("attributesJson", attributesJson);
+      return toMapResult;
+    }
+    static ActionResponsePigeon fromMap(HashMap map) {
+      ActionResponsePigeon fromMapResult = new ActionResponsePigeon();
+      Object success = map.get("success");
+      fromMapResult.success = (Boolean)success;
+      Object attributesJson = map.get("attributesJson");
+      fromMapResult.attributesJson = (String)attributesJson;
+      return fromMapResult;
+    }
+  }
+
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static class ActionTrigger {
+    private String itemId;
+    public String getItemId() { return itemId; }
+    public void setItemId(String setterArg) { this.itemId = setterArg; }
+
+    private Long actionId;
+    public Long getActionId() { return actionId; }
+    public void setActionId(Long setterArg) { this.actionId = setterArg; }
+
+    private String attributesJson;
+    public String getAttributesJson() { return attributesJson; }
+    public void setAttributesJson(String setterArg) { this.attributesJson = setterArg; }
+
+    HashMap toMap() {
+      HashMap<String, Object> toMapResult = new HashMap<>();
+      toMapResult.put("itemId", itemId);
+      toMapResult.put("actionId", actionId);
+      toMapResult.put("attributesJson", attributesJson);
+      return toMapResult;
+    }
+    static ActionTrigger fromMap(HashMap map) {
+      ActionTrigger fromMapResult = new ActionTrigger();
+      Object itemId = map.get("itemId");
+      fromMapResult.itemId = (String)itemId;
+      Object actionId = map.get("actionId");
+      fromMapResult.actionId = (actionId == null) ? null : ((actionId instanceof Integer) ? (Integer)actionId : (Long)actionId);
+      Object attributesJson = map.get("attributesJson");
+      fromMapResult.attributesJson = (String)attributesJson;
+      return fromMapResult;
+    }
+  }
+
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface PigeonLogger {
+    void v(StringWrapper arg);
+    void d(StringWrapper arg);
+    void i(StringWrapper arg);
+    void w(StringWrapper arg);
+    void e(StringWrapper arg);
+
+    /** Sets up an instance of `PigeonLogger` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, PigeonLogger api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.v", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.v(input);
+              wrapped.put("result", null);
             }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.d", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.d(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
             }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.i", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.i(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.w", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.w(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.e", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.e(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.d", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.d(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.i", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.i(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.w", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.w(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PigeonLogger.e", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.e(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface WorkaroundsControl {
-        ListWrapper getNeededWorkarounds();
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface WorkaroundsControl {
+    ListWrapper getNeededWorkarounds();
 
-        /**
-         * Sets up an instance of `WorkaroundsControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, WorkaroundsControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.WorkaroundsControl.getNeededWorkarounds", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            ListWrapper output = api.getNeededWorkarounds();
-                            wrapped.put("result", output.toMap());
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `WorkaroundsControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, WorkaroundsControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.WorkaroundsControl.getNeededWorkarounds", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              ListWrapper output = api.getNeededWorkarounds();
+              wrapped.put("result", output.toMap());
             }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
     }
+  }
 
-    public interface Result<T> {
-        void success(T result);
+  public interface Result<T> {
+    void success(T result);
+  }
+
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface AppLifecycleControl {
+    void openAppOnTheWatch(StringWrapper arg, Result<BooleanWrapper> result);
+
+    /** Sets up an instance of `AppLifecycleControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, AppLifecycleControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppLifecycleControl.openAppOnTheWatch", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.openAppOnTheWatch(input, result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface AppLifecycleControl {
-        void openAppOnTheWatch(StringWrapper arg, Result<BooleanWrapper> result);
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface BackgroundControl {
+    void notifyFlutterBackgroundStarted(Result<NumberWrapper> result);
 
-        /**
-         * Sets up an instance of `AppLifecycleControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, AppLifecycleControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppLifecycleControl.openAppOnTheWatch", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.openAppOnTheWatch(input, result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `BackgroundControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, BackgroundControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.BackgroundControl.notifyFlutterBackgroundStarted", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.notifyFlutterBackgroundStarted(result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
             }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface BackgroundControl {
-        void notifyFlutterBackgroundStarted(Result<NumberWrapper> result);
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface BackgroundSetupControl {
+    void setupBackground(NumberWrapper arg);
 
-        /**
-         * Sets up an instance of `BackgroundControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, BackgroundControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.BackgroundControl.notifyFlutterBackgroundStarted", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.notifyFlutterBackgroundStarted(result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `BackgroundSetupControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, BackgroundSetupControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.BackgroundSetupControl.setupBackground", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              NumberWrapper input = NumberWrapper.fromMap((HashMap)message);
+              api.setupBackground(input);
+              wrapped.put("result", null);
             }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface BackgroundSetupControl {
-        void setupBackground(NumberWrapper arg);
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface AppLogControl {
+    void startSendingLogs();
+    void stopSendingLogs();
 
-        /**
-         * Sets up an instance of `BackgroundSetupControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, BackgroundSetupControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.BackgroundSetupControl.setupBackground", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            NumberWrapper input = NumberWrapper.fromMap((HashMap) message);
-                            api.setupBackground(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `AppLogControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, AppLogControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppLogControl.startSendingLogs", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.startSendingLogs();
+              wrapped.put("result", null);
             }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppLogControl.stopSendingLogs", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.stopSendingLogs();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface AppLogControl {
-        void startSendingLogs();
-
-        void stopSendingLogs();
-
-        /**
-         * Sets up an instance of `AppLogControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, AppLogControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppLogControl.startSendingLogs", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.startSendingLogs();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppLogControl.stopSendingLogs", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.stopSendingLogs();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-        }
+  /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
+  public static class ScanCallbacks {
+    private final BinaryMessenger binaryMessenger;
+    public ScanCallbacks(BinaryMessenger argBinaryMessenger){
+      this.binaryMessenger = argBinaryMessenger;
     }
-
-    /**
-     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
-     */
-    public static class ScanCallbacks {
-        private final BinaryMessenger binaryMessenger;
-
-        public ScanCallbacks(BinaryMessenger argBinaryMessenger) {
-            this.binaryMessenger = argBinaryMessenger;
-        }
-
-        public interface Reply<T> {
-            void reply(T reply);
-        }
-
-        public void onScanUpdate(ListWrapper argInput, Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanCallbacks.onScanUpdate", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                callback.reply(null);
-            });
-        }
-
-        public void onScanStarted(Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanCallbacks.onScanStarted", new StandardMessageCodec());
-            channel.send(null, channelReply -> {
-                callback.reply(null);
-            });
-        }
-
-        public void onScanStopped(Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanCallbacks.onScanStopped", new StandardMessageCodec());
-            channel.send(null, channelReply -> {
-                callback.reply(null);
-            });
-        }
+    public interface Reply<T> {
+      void reply(T reply);
     }
-
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface IntentControl {
-        void notifyFlutterReadyForIntents();
-
-        void notifyFlutterNotReadyForIntents();
-
-        BooleanWrapper waitForBoot();
-
-        /**
-         * Sets up an instance of `IntentControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, IntentControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.IntentControl.notifyFlutterReadyForIntents", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.notifyFlutterReadyForIntents();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.IntentControl.notifyFlutterNotReadyForIntents", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.notifyFlutterNotReadyForIntents();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.IntentControl.waitForBoot", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            BooleanWrapper output = api.waitForBoot();
-                            wrapped.put("result", output.toMap());
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-        }
+    public void onScanUpdate(ListWrapper argInput, Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanCallbacks.onScanUpdate", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        callback.reply(null);
+      });
     }
-
-    /**
-     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
-     */
-    public static class NotificationListening {
-        private final BinaryMessenger binaryMessenger;
-
-        public NotificationListening(BinaryMessenger argBinaryMessenger) {
-            this.binaryMessenger = argBinaryMessenger;
-        }
-
-        public interface Reply<T> {
-            void reply(T reply);
-        }
-
-        public void handleNotification(NotificationPigeon argInput, Reply<TimelinePinPigeon> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationListening.handleNotification", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                HashMap outputMap = (HashMap) channelReply;
-                @SuppressWarnings("ConstantConditions")
-                TimelinePinPigeon output = TimelinePinPigeon.fromMap(outputMap);
-                callback.reply(output);
-            });
-        }
-
-        public void dismissNotification(StringWrapper argInput, Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationListening.dismissNotification", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                callback.reply(null);
-            });
-        }
+    public void onScanStarted(Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanCallbacks.onScanStarted", new StandardMessageCodec());
+      channel.send(null, channelReply -> {
+        callback.reply(null);
+      });
     }
-
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface KeepUnusedHack {
-        void keepPebbleScanDevicePigeon(PebbleScanDevicePigeon arg);
-
-        void keepWatchResource(WatchResource arg);
-
-        /**
-         * Sets up an instance of `KeepUnusedHack` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, KeepUnusedHack api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.KeepUnusedHack.keepPebbleScanDevicePigeon", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            PebbleScanDevicePigeon input = PebbleScanDevicePigeon.fromMap((HashMap) message);
-                            api.keepPebbleScanDevicePigeon(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.KeepUnusedHack.keepWatchResource", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            WatchResource input = WatchResource.fromMap((HashMap) message);
-                            api.keepWatchResource(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-        }
+    public void onScanStopped(Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanCallbacks.onScanStopped", new StandardMessageCodec());
+      channel.send(null, channelReply -> {
+        callback.reply(null);
+      });
     }
+  }
 
-    /**
-     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
-     */
-    public static class PairCallbacks {
-        private final BinaryMessenger binaryMessenger;
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface IntentControl {
+    void notifyFlutterReadyForIntents();
+    void notifyFlutterNotReadyForIntents();
+    BooleanWrapper waitForBoot();
 
-        public PairCallbacks(BinaryMessenger argBinaryMessenger) {
-            this.binaryMessenger = argBinaryMessenger;
+    /** Sets up an instance of `IntentControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, IntentControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.IntentControl.notifyFlutterReadyForIntents", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.notifyFlutterReadyForIntents();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
-
-        public interface Reply<T> {
-            void reply(T reply);
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.IntentControl.notifyFlutterNotReadyForIntents", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.notifyFlutterNotReadyForIntents();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
-
-        public void onWatchPairComplete(NumberWrapper argInput, Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PairCallbacks.onWatchPairComplete", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                callback.reply(null);
-            });
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.IntentControl.waitForBoot", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              BooleanWrapper output = api.waitForBoot();
+              wrapped.put("result", output.toMap());
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface PermissionCheck {
-        BooleanWrapper hasLocationPermission();
-
-        BooleanWrapper hasCalendarPermission();
-
-        BooleanWrapper hasNotificationAccess();
-
-        BooleanWrapper hasBatteryExclusionEnabled();
-
-        /**
-         * Sets up an instance of `PermissionCheck` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, PermissionCheck api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionCheck.hasLocationPermission", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            BooleanWrapper output = api.hasLocationPermission();
-                            wrapped.put("result", output.toMap());
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionCheck.hasCalendarPermission", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            BooleanWrapper output = api.hasCalendarPermission();
-                            wrapped.put("result", output.toMap());
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionCheck.hasNotificationAccess", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            BooleanWrapper output = api.hasNotificationAccess();
-                            wrapped.put("result", output.toMap());
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionCheck.hasBatteryExclusionEnabled", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            BooleanWrapper output = api.hasBatteryExclusionEnabled();
-                            wrapped.put("result", output.toMap());
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-        }
+  /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
+  public static class NotificationListening {
+    private final BinaryMessenger binaryMessenger;
+    public NotificationListening(BinaryMessenger argBinaryMessenger){
+      this.binaryMessenger = argBinaryMessenger;
     }
-
-    /**
-     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
-     */
-    public static class ConnectionCallbacks {
-        private final BinaryMessenger binaryMessenger;
-
-        public ConnectionCallbacks(BinaryMessenger argBinaryMessenger) {
-            this.binaryMessenger = argBinaryMessenger;
-        }
-
-        public interface Reply<T> {
-            void reply(T reply);
-        }
-
-        public void onWatchConnectionStateChanged(WatchConnectionStatePigeon argInput, Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ConnectionCallbacks.onWatchConnectionStateChanged", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                callback.reply(null);
-            });
-        }
+    public interface Reply<T> {
+      void reply(T reply);
     }
+    public void handleNotification(NotificationPigeon argInput, Reply<TimelinePinPigeon> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationListening.handleNotification", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        HashMap outputMap = (HashMap)channelReply;
+        @SuppressWarnings("ConstantConditions")
+        TimelinePinPigeon output = TimelinePinPigeon.fromMap(outputMap);
+        callback.reply(output);
+      });
+    }
+    public void dismissNotification(StringWrapper argInput, Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationListening.dismissNotification", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        callback.reply(null);
+      });
+    }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface DebugControl {
-        void collectLogs();
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface KeepUnusedHack {
+    void keepPebbleScanDevicePigeon(PebbleScanDevicePigeon arg);
+    void keepWatchResource(WatchResource arg);
 
-        /**
-         * Sets up an instance of `DebugControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, DebugControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.DebugControl.collectLogs", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.collectLogs();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `KeepUnusedHack` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, KeepUnusedHack api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.KeepUnusedHack.keepPebbleScanDevicePigeon", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              PebbleScanDevicePigeon input = PebbleScanDevicePigeon.fromMap((HashMap)message);
+              api.keepPebbleScanDevicePigeon(input);
+              wrapped.put("result", null);
             }
-        }
-    }
-
-    /**
-     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
-     */
-    public static class CalendarCallbacks {
-        private final BinaryMessenger binaryMessenger;
-
-        public CalendarCallbacks(BinaryMessenger argBinaryMessenger) {
-            this.binaryMessenger = argBinaryMessenger;
-        }
-
-        public interface Reply<T> {
-            void reply(T reply);
-        }
-
-        public void doFullCalendarSync(Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarCallbacks.doFullCalendarSync", new StandardMessageCodec());
-            channel.send(null, channelReply -> {
-                callback.reply(null);
-            });
-        }
-
-        public void deleteCalendarPinsFromWatch(Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarCallbacks.deleteCalendarPinsFromWatch", new StandardMessageCodec());
-            channel.send(null, channelReply -> {
-                callback.reply(null);
-            });
-        }
-    }
-
-    /**
-     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
-     */
-    public static class AppInstallStatusCallbacks {
-        private final BinaryMessenger binaryMessenger;
-
-        public AppInstallStatusCallbacks(BinaryMessenger argBinaryMessenger) {
-            this.binaryMessenger = argBinaryMessenger;
-        }
-
-        public interface Reply<T> {
-            void reply(T reply);
-        }
-
-        public void onStatusUpdated(AppInstallStatus argInput, Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallStatusCallbacks.onStatusUpdated", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                callback.reply(null);
-            });
-        }
-    }
-
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface ScanControl {
-        void startBleScan();
-
-        void startClassicScan();
-
-        /** Sets up an instance of `ScanControl` to handle messages through the `binaryMessenger` */
-        static void setup(BinaryMessenger binaryMessenger, ScanControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanControl.startBleScan", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.startBleScan();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
             }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanControl.startClassicScan", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.startClassicScan();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.KeepUnusedHack.keepWatchResource", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              WatchResource input = WatchResource.fromMap((HashMap)message);
+              api.keepWatchResource(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+
+  /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
+  public static class PairCallbacks {
+    private final BinaryMessenger binaryMessenger;
+    public PairCallbacks(BinaryMessenger argBinaryMessenger){
+      this.binaryMessenger = argBinaryMessenger;
+    }
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    public void onWatchPairComplete(NumberWrapper argInput, Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PairCallbacks.onWatchPairComplete", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        callback.reply(null);
+      });
+    }
+  }
+
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface PermissionCheck {
+    BooleanWrapper hasLocationPermission();
+    BooleanWrapper hasCalendarPermission();
+    BooleanWrapper hasNotificationAccess();
+    BooleanWrapper hasBatteryExclusionEnabled();
+
+    /** Sets up an instance of `PermissionCheck` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, PermissionCheck api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionCheck.hasLocationPermission", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              BooleanWrapper output = api.hasLocationPermission();
+              wrapped.put("result", output.toMap());
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionCheck.hasCalendarPermission", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              BooleanWrapper output = api.hasCalendarPermission();
+              wrapped.put("result", output.toMap());
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionCheck.hasNotificationAccess", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              BooleanWrapper output = api.hasNotificationAccess();
+              wrapped.put("result", output.toMap());
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionCheck.hasBatteryExclusionEnabled", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              BooleanWrapper output = api.hasBatteryExclusionEnabled();
+              wrapped.put("result", output.toMap());
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+
+  /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
+  public static class ConnectionCallbacks {
+    private final BinaryMessenger binaryMessenger;
+    public ConnectionCallbacks(BinaryMessenger argBinaryMessenger){
+      this.binaryMessenger = argBinaryMessenger;
+    }
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    public void onWatchConnectionStateChanged(WatchConnectionStatePigeon argInput, Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ConnectionCallbacks.onWatchConnectionStateChanged", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        callback.reply(null);
+      });
+    }
+  }
+
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface DebugControl {
+    void collectLogs();
+
+    /** Sets up an instance of `DebugControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, DebugControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.DebugControl.collectLogs", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.collectLogs();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+
+  /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
+  public static class CalendarCallbacks {
+    private final BinaryMessenger binaryMessenger;
+    public CalendarCallbacks(BinaryMessenger argBinaryMessenger){
+      this.binaryMessenger = argBinaryMessenger;
+    }
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    public void doFullCalendarSync(Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarCallbacks.doFullCalendarSync", new StandardMessageCodec());
+      channel.send(null, channelReply -> {
+        callback.reply(null);
+      });
+    }
+    public void deleteCalendarPinsFromWatch(Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarCallbacks.deleteCalendarPinsFromWatch", new StandardMessageCodec());
+      channel.send(null, channelReply -> {
+        callback.reply(null);
+      });
+    }
+  }
+
+  /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
+  public static class AppInstallStatusCallbacks {
+    private final BinaryMessenger binaryMessenger;
+    public AppInstallStatusCallbacks(BinaryMessenger argBinaryMessenger){
+      this.binaryMessenger = argBinaryMessenger;
+    }
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    public void onStatusUpdated(AppInstallStatus argInput, Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallStatusCallbacks.onStatusUpdated", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        callback.reply(null);
+      });
+    }
+  }
+
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface ScanControl {
+    void startBleScan();
+    void startClassicScan();
+
+    /** Sets up an instance of `ScanControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, ScanControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanControl.startBleScan", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.startBleScan();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScanControl.startClassicScan", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.startClassicScan();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
   }
 
   /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
@@ -2182,165 +1739,151 @@ public class Pigeons {
             catch (Exception exception) {
               wrapped.put("error", wrapError(exception));
             }
-              reply.reply(wrapped);
+            reply.reply(wrapped);
           });
         } else {
-            channel.setMessageHandler(null);
+          channel.setMessageHandler(null);
         }
       }
     }
   }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface PermissionControl {
-        NumberWrapper requestLocationPermission();
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface PermissionControl {
+    NumberWrapper requestLocationPermission();
+    NumberWrapper requestCalendarPermission();
+    void requestNotificationAccess();
+    void requestBatteryExclusion();
+    void openPermissionSettings();
 
-        NumberWrapper requestCalendarPermission();
-
-        void requestNotificationAccess();
-
-        void requestBatteryExclusion();
-
-        void openPermissionSettings();
-
-        /**
-         * Sets up an instance of `PermissionControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, PermissionControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.requestLocationPermission", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            NumberWrapper output = api.requestLocationPermission();
-                            wrapped.put("result", output.toMap());
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `PermissionControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, PermissionControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.requestLocationPermission", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              NumberWrapper output = api.requestLocationPermission();
+              wrapped.put("result", output.toMap());
             }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.requestCalendarPermission", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            NumberWrapper output = api.requestCalendarPermission();
-                            wrapped.put("result", output.toMap());
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
             }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.requestNotificationAccess", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.requestNotificationAccess();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.requestBatteryExclusion", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.requestBatteryExclusion();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.openPermissionSettings", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.openPermissionSettings();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.requestCalendarPermission", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              NumberWrapper output = api.requestCalendarPermission();
+              wrapped.put("result", output.toMap());
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.requestNotificationAccess", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.requestNotificationAccess();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.requestBatteryExclusion", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.requestBatteryExclusion();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PermissionControl.openPermissionSettings", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.openPermissionSettings();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
     }
+  }
 
-    /**
-     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
-     */
-    public static class AppLogCallbacks {
-        private final BinaryMessenger binaryMessenger;
-
-        public AppLogCallbacks(BinaryMessenger argBinaryMessenger) {
-            this.binaryMessenger = argBinaryMessenger;
-        }
-
-        public interface Reply<T> {
-            void reply(T reply);
-        }
-
-        public void onLogReceived(AppLogEntry argInput, Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppLogCallbacks.onLogReceived", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                callback.reply(null);
-            });
-        }
+  /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
+  public static class AppLogCallbacks {
+    private final BinaryMessenger binaryMessenger;
+    public AppLogCallbacks(BinaryMessenger argBinaryMessenger){
+      this.binaryMessenger = argBinaryMessenger;
     }
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    public void onLogReceived(AppLogEntry argInput, Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppLogCallbacks.onLogReceived", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        callback.reply(null);
+      });
+    }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface ConnectionControl {
-        BooleanWrapper isConnected();
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface ConnectionControl {
+    BooleanWrapper isConnected();
+    void disconnect();
+    void sendRawPacket(ListWrapper arg);
+    void observeConnectionChanges();
+    void cancelObservingConnectionChanges();
 
-        void disconnect();
-
-        void sendRawPacket(ListWrapper arg);
-
-        void observeConnectionChanges();
-
-        void cancelObservingConnectionChanges();
-
-        /** Sets up an instance of `ConnectionControl` to handle messages through the `binaryMessenger` */
+    /** Sets up an instance of `ConnectionControl` to handle messages through the `binaryMessenger` */
     static void setup(BinaryMessenger binaryMessenger, ConnectionControl api) {
       {
         BasicMessageChannel<Object> channel =
@@ -2390,491 +1933,408 @@ public class Pigeons {
               @SuppressWarnings("ConstantConditions")
               ListWrapper input = ListWrapper.fromMap((HashMap)message);
               api.sendRawPacket(input);
-                wrapped.put("result", null);
-            } catch (Exception exception) {
-                wrapped.put("error", wrapError(exception));
+              wrapped.put("result", null);
             }
-              reply.reply(wrapped);
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
           });
         } else {
-            channel.setMessageHandler(null);
+          channel.setMessageHandler(null);
         }
       }
-        {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ConnectionControl.observeConnectionChanges", new StandardMessageCodec());
-            if (api != null) {
-                channel.setMessageHandler((message, reply) -> {
-                    HashMap<String, HashMap> wrapped = new HashMap<>();
-                    try {
-                        api.observeConnectionChanges();
-                        wrapped.put("result", null);
-                    } catch (Exception exception) {
-                        wrapped.put("error", wrapError(exception));
-                    }
-                    reply.reply(wrapped);
-                });
-            } else {
-                channel.setMessageHandler(null);
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ConnectionControl.observeConnectionChanges", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.observeConnectionChanges();
+              wrapped.put("result", null);
             }
-        }
-        {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ConnectionControl.cancelObservingConnectionChanges", new StandardMessageCodec());
-            if (api != null) {
-                channel.setMessageHandler((message, reply) -> {
-                    HashMap<String, HashMap> wrapped = new HashMap<>();
-                    try {
-                        api.cancelObservingConnectionChanges();
-                        wrapped.put("result", null);
-                    } catch (Exception exception) {
-                        wrapped.put("error", wrapError(exception));
-                    }
-                    reply.reply(wrapped);
-                });
-            } else {
-                channel.setMessageHandler(null);
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
             }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ConnectionControl.cancelObservingConnectionChanges", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.cancelObservingConnectionChanges();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
     }
   }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface NotificationsControl {
-        void sendTestNotification();
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface NotificationsControl {
+    void sendTestNotification();
 
-        /**
-         * Sets up an instance of `NotificationsControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, NotificationsControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationsControl.sendTestNotification", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.sendTestNotification();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `NotificationsControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, NotificationsControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationsControl.sendTestNotification", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.sendTestNotification();
+              wrapped.put("result", null);
             }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
     }
+  }
 
-    /**
-     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
-     */
-    public static class BackgroundAppInstallCallbacks {
-        private final BinaryMessenger binaryMessenger;
-
-        public BackgroundAppInstallCallbacks(BinaryMessenger argBinaryMessenger) {
-            this.binaryMessenger = argBinaryMessenger;
-        }
-
-        public interface Reply<T> {
-            void reply(T reply);
-        }
-
-        public void beginAppInstall(InstallData argInput, Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.BackgroundAppInstallCallbacks.beginAppInstall", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                callback.reply(null);
-            });
-        }
-
-        public void deleteApp(StringWrapper argInput, Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.BackgroundAppInstallCallbacks.deleteApp", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                callback.reply(null);
-            });
-        }
-
-        public void beginAppOrderChange(AppReorderRequest argInput, Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.BackgroundAppInstallCallbacks.beginAppOrderChange", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                callback.reply(null);
-            });
-        }
+  /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
+  public static class BackgroundAppInstallCallbacks {
+    private final BinaryMessenger binaryMessenger;
+    public BackgroundAppInstallCallbacks(BinaryMessenger argBinaryMessenger){
+      this.binaryMessenger = argBinaryMessenger;
     }
-
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface AppInstallControl {
-        void getAppInfo(StringWrapper arg, Result<PbwAppInfo> result);
-
-        void beginAppInstall(InstallData arg, Result<BooleanWrapper> result);
-
-        void beginAppDeletion(StringWrapper arg, Result<BooleanWrapper> result);
-
-        void insertAppIntoBlobDb(StringWrapper arg, Result<NumberWrapper> result);
-
-        void removeAppFromBlobDb(StringWrapper arg, Result<NumberWrapper> result);
-
-        void removeAllApps(Result<NumberWrapper> result);
-
-        void beginAppOrderChange(AppReorderRequest arg, Result<NumberWrapper> result);
-
-        void subscribeToAppStatus();
-
-        void unsubscribeFromAppStatus();
-
-        void sendAppOrderToWatch(ListWrapper arg, Result<NumberWrapper> result);
-
-        /**
-         * Sets up an instance of `AppInstallControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, AppInstallControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.getAppInfo", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.getAppInfo(input, result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.beginAppInstall", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            InstallData input = InstallData.fromMap((HashMap) message);
-                            api.beginAppInstall(input, result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.beginAppDeletion", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.beginAppDeletion(input, result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.insertAppIntoBlobDb", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.insertAppIntoBlobDb(input, result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.removeAppFromBlobDb", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.removeAppFromBlobDb(input, result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.removeAllApps", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.removeAllApps(result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.beginAppOrderChange", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            AppReorderRequest input = AppReorderRequest.fromMap((HashMap) message);
-                            api.beginAppOrderChange(input, result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.subscribeToAppStatus", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.subscribeToAppStatus();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.unsubscribeFromAppStatus", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.unsubscribeFromAppStatus();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.sendAppOrderToWatch", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            ListWrapper input = ListWrapper.fromMap((HashMap) message);
-                            api.sendAppOrderToWatch(input, result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-        }
+    public interface Reply<T> {
+      void reply(T reply);
     }
-
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface TimelineSyncControl {
-        void syncTimelineToWatchLater();
-
-        /**
-         * Sets up an instance of `TimelineSyncControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, TimelineSyncControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.TimelineSyncControl.syncTimelineToWatchLater", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.syncTimelineToWatchLater();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-        }
+    public void beginAppInstall(InstallData argInput, Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.BackgroundAppInstallCallbacks.beginAppInstall", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        callback.reply(null);
+      });
     }
-
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface PackageDetails {
-        AppEntriesPigeon getPackageList();
-
-        /**
-         * Sets up an instance of `PackageDetails` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, PackageDetails api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PackageDetails.getPackageList", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            AppEntriesPigeon output = api.getPackageList();
-                            wrapped.put("result", output.toMap());
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
-            }
-        }
+    public void deleteApp(StringWrapper argInput, Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.BackgroundAppInstallCallbacks.deleteApp", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        callback.reply(null);
+      });
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface ScreenshotsControl {
-        void takeWatchScreenshot(Result<ScreenshotResult> result);
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface AppInstallControl {
+    void getAppInfo(StringWrapper arg, Result<PbwAppInfo> result);
+    void beginAppInstall(InstallData arg, Result<BooleanWrapper> result);
+    void beginAppDeletion(StringWrapper arg, Result<BooleanWrapper> result);
+    void insertAppIntoBlobDb(StringWrapper arg, Result<NumberWrapper> result);
+    void removeAppFromBlobDb(StringWrapper arg, Result<NumberWrapper> result);
+    void removeAllApps(Result<NumberWrapper> result);
+    void subscribeToAppStatus();
+    void unsubscribeFromAppStatus();
+    void sendAppOrderToWatch(ListWrapper arg, Result<NumberWrapper> result);
 
-        /**
-         * Sets up an instance of `ScreenshotsControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, ScreenshotsControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScreenshotsControl.takeWatchScreenshot", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.takeWatchScreenshot(result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                            reply.reply(wrapped);
-                        }
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `AppInstallControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, AppInstallControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.getAppInfo", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.getAppInfo(input, result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
             }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.beginAppInstall", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              InstallData input = InstallData.fromMap((HashMap)message);
+              api.beginAppInstall(input, result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.beginAppDeletion", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.beginAppDeletion(input, result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.insertAppIntoBlobDb", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.insertAppIntoBlobDb(input, result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.removeAppFromBlobDb", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.removeAppFromBlobDb(input, result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.removeAllApps", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.removeAllApps(result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.subscribeToAppStatus", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.subscribeToAppStatus();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.unsubscribeFromAppStatus", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.unsubscribeFromAppStatus();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.AppInstallControl.sendAppOrderToWatch", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              ListWrapper input = ListWrapper.fromMap((HashMap)message);
+              api.sendAppOrderToWatch(input, result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface NotificationUtils {
-        void dismissNotification(StringWrapper arg, Result<BooleanWrapper> result);
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface TimelineSyncControl {
+    void syncTimelineToWatchLater();
 
-        void dismissNotificationWatch(StringWrapper arg);
+    /** Sets up an instance of `TimelineSyncControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, TimelineSyncControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.TimelineSyncControl.syncTimelineToWatchLater", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.syncTimelineToWatchLater();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
 
-        void openNotification(StringWrapper arg);
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface PackageDetails {
+    AppEntriesPigeon getPackageList();
 
-        void executeAction(NotifActionExecuteReq arg);
+    /** Sets up an instance of `PackageDetails` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, PackageDetails api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PackageDetails.getPackageList", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              AppEntriesPigeon output = api.getPackageList();
+              wrapped.put("result", output.toMap());
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
 
-        /** Sets up an instance of `NotificationUtils` to handle messages through the `binaryMessenger` */
-        static void setup(BinaryMessenger binaryMessenger, NotificationUtils api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationUtils.dismissNotification", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            StringWrapper input = StringWrapper.fromMap((HashMap) message);
-                            api.dismissNotification(input, result -> {
-                                wrapped.put("result", result.toMap());
-                                reply.reply(wrapped);
-                            });
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface ScreenshotsControl {
+    void takeWatchScreenshot(Result<ScreenshotResult> result);
+
+    /** Sets up an instance of `ScreenshotsControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, ScreenshotsControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.ScreenshotsControl.takeWatchScreenshot", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.takeWatchScreenshot(result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+              reply.reply(wrapped);
+            }
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface NotificationUtils {
+    void dismissNotification(StringWrapper arg, Result<BooleanWrapper> result);
+    void dismissNotificationWatch(StringWrapper arg);
+    void openNotification(StringWrapper arg);
+    void executeAction(NotifActionExecuteReq arg);
+
+    /** Sets up an instance of `NotificationUtils` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, NotificationUtils api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationUtils.dismissNotification", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              StringWrapper input = StringWrapper.fromMap((HashMap)message);
+              api.dismissNotification(input, result -> { wrapped.put("result", result.toMap()); reply.reply(wrapped); });
             }
             catch (Exception exception) {
               wrapped.put("error", wrapError(exception));
@@ -2916,173 +2376,165 @@ public class Pigeons {
               @SuppressWarnings("ConstantConditions")
               StringWrapper input = StringWrapper.fromMap((HashMap)message);
               api.openNotification(input);
-                wrapped.put("result", null);
-            } catch (Exception exception) {
-                wrapped.put("error", wrapError(exception));
+              wrapped.put("result", null);
             }
-              reply.reply(wrapped);
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
           });
         } else {
-            channel.setMessageHandler(null);
+          channel.setMessageHandler(null);
         }
       }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationUtils.executeAction", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            NotifActionExecuteReq input = NotifActionExecuteReq.fromMap((HashMap) message);
-                            api.executeAction(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.NotificationUtils.executeAction", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              NotifActionExecuteReq input = NotifActionExecuteReq.fromMap((HashMap)message);
+              api.executeAction(input);
+              wrapped.put("result", null);
             }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
     }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface CalendarControl {
-        void requestCalendarSync();
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface CalendarControl {
+    void requestCalendarSync();
+    void deleteCalendarPinsFromWatch();
 
-        void deleteCalendarPinsFromWatch();
-
-        /**
-         * Sets up an instance of `CalendarControl` to handle messages through the `binaryMessenger`
-         */
-        static void setup(BinaryMessenger binaryMessenger, CalendarControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarControl.requestCalendarSync", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.requestCalendarSync();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `CalendarControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, CalendarControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarControl.requestCalendarSync", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.requestCalendarSync();
+              wrapped.put("result", null);
             }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarControl.deleteCalendarPinsFromWatch", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            api.deleteCalendarPinsFromWatch();
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
             }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarControl.deleteCalendarPinsFromWatch", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.deleteCalendarPinsFromWatch();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
     }
+  }
 
-    /**
-     * Generated class from Pigeon that represents Flutter messages that can be called from Java.
-     */
-    public static class TimelineCallbacks {
-        private final BinaryMessenger binaryMessenger;
-
-        public TimelineCallbacks(BinaryMessenger argBinaryMessenger) {
-            this.binaryMessenger = argBinaryMessenger;
-        }
-
-        public interface Reply<T> {
-            void reply(T reply);
-        }
-
-        public void syncTimelineToWatch(Reply<Void> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.TimelineCallbacks.syncTimelineToWatch", new StandardMessageCodec());
-            channel.send(null, channelReply -> {
-                callback.reply(null);
-            });
-        }
-
-        public void handleTimelineAction(ActionTrigger argInput, Reply<ActionResponsePigeon> callback) {
-            BasicMessageChannel<Object> channel =
-                    new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.TimelineCallbacks.handleTimelineAction", new StandardMessageCodec());
-            HashMap inputMap = argInput.toMap();
-            channel.send(inputMap, channelReply -> {
-                HashMap outputMap = (HashMap) channelReply;
-                @SuppressWarnings("ConstantConditions")
-                ActionResponsePigeon output = ActionResponsePigeon.fromMap(outputMap);
-                callback.reply(output);
-            });
-        }
+  /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
+  public static class TimelineCallbacks {
+    private final BinaryMessenger binaryMessenger;
+    public TimelineCallbacks(BinaryMessenger argBinaryMessenger){
+      this.binaryMessenger = argBinaryMessenger;
     }
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    public void syncTimelineToWatch(Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.TimelineCallbacks.syncTimelineToWatch", new StandardMessageCodec());
+      channel.send(null, channelReply -> {
+        callback.reply(null);
+      });
+    }
+    public void handleTimelineAction(ActionTrigger argInput, Reply<ActionResponsePigeon> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.TimelineCallbacks.handleTimelineAction", new StandardMessageCodec());
+      HashMap inputMap = argInput.toMap();
+      channel.send(inputMap, channelReply -> {
+        HashMap outputMap = (HashMap)channelReply;
+        @SuppressWarnings("ConstantConditions")
+        ActionResponsePigeon output = ActionResponsePigeon.fromMap(outputMap);
+        callback.reply(output);
+      });
+    }
+  }
 
-    /**
-     * Generated interface from Pigeon that represents a handler of messages from Flutter.
-     */
-    public interface UiConnectionControl {
-        void connectToWatch(NumberWrapper arg);
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
+  public interface UiConnectionControl {
+    void connectToWatch(NumberWrapper arg);
+    void unpairWatch(NumberWrapper arg);
 
-        void unpairWatch(NumberWrapper arg);
-
-        /** Sets up an instance of `UiConnectionControl` to handle messages through the `binaryMessenger` */
-        static void setup(BinaryMessenger binaryMessenger, UiConnectionControl api) {
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.UiConnectionControl.connectToWatch", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            NumberWrapper input = NumberWrapper.fromMap((HashMap) message);
-                            api.connectToWatch(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
-                }
+    /** Sets up an instance of `UiConnectionControl` to handle messages through the `binaryMessenger` */
+    static void setup(BinaryMessenger binaryMessenger, UiConnectionControl api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.UiConnectionControl.connectToWatch", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              NumberWrapper input = NumberWrapper.fromMap((HashMap)message);
+              api.connectToWatch(input);
+              wrapped.put("result", null);
             }
-            {
-                BasicMessageChannel<Object> channel =
-                        new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.UiConnectionControl.unpairWatch", new StandardMessageCodec());
-                if (api != null) {
-                    channel.setMessageHandler((message, reply) -> {
-                        HashMap<String, HashMap> wrapped = new HashMap<>();
-                        try {
-                            @SuppressWarnings("ConstantConditions")
-                            NumberWrapper input = NumberWrapper.fromMap((HashMap) message);
-                            api.unpairWatch(input);
-                            wrapped.put("result", null);
-                        } catch (Exception exception) {
-                            wrapped.put("error", wrapError(exception));
-                        }
-                        reply.reply(wrapped);
-                    });
-                } else {
-                    channel.setMessageHandler(null);
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.UiConnectionControl.unpairWatch", new StandardMessageCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              NumberWrapper input = NumberWrapper.fromMap((HashMap)message);
+              api.unpairWatch(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
         }
       }
     }

--- a/android/app/src/main/java/io/rebble/cobble/pigeons/Pigeons.java
+++ b/android/app/src/main/java/io/rebble/cobble/pigeons/Pigeons.java
@@ -1581,13 +1581,6 @@ public class Pigeons {
         callback.reply(null);
       });
     }
-    public void deleteCalendarPinsFromWatch(Reply<Void> callback) {
-      BasicMessageChannel<Object> channel =
-          new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarCallbacks.deleteCalendarPinsFromWatch", new StandardMessageCodec());
-      channel.send(null, channelReply -> {
-        callback.reply(null);
-      });
-    }
   }
 
   /** Generated class from Pigeon that represents Flutter messages that can be called from Java.*/
@@ -2414,7 +2407,6 @@ public class Pigeons {
   /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
   public interface CalendarControl {
     void requestCalendarSync();
-    void deleteCalendarPinsFromWatch();
 
     /** Sets up an instance of `CalendarControl` to handle messages through the `binaryMessenger` */
     static void setup(BinaryMessenger binaryMessenger, CalendarControl api) {
@@ -2426,25 +2418,6 @@ public class Pigeons {
             HashMap<String, HashMap> wrapped = new HashMap<>();
             try {
               api.requestCalendarSync();
-              wrapped.put("result", null);
-            }
-            catch (Exception exception) {
-              wrapped.put("error", wrapError(exception));
-            }
-            reply.reply(wrapped);
-          });
-        } else {
-          channel.setMessageHandler(null);
-        }
-      }
-      {
-        BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.CalendarControl.deleteCalendarPinsFromWatch", new StandardMessageCodec());
-        if (api != null) {
-          channel.setMessageHandler((message, reply) -> {
-            HashMap<String, HashMap> wrapped = new HashMap<>();
-            try {
-              api.deleteCalendarPinsFromWatch();
               wrapped.put("result", null);
             }
             catch (Exception exception) {

--- a/android/app/src/main/kotlin/io/rebble/cobble/bridges/background/BackgroundAppInstallBridge.kt
+++ b/android/app/src/main/kotlin/io/rebble/cobble/bridges/background/BackgroundAppInstallBridge.kt
@@ -2,7 +2,6 @@ package io.rebble.cobble.bridges.background
 
 import io.rebble.cobble.bridges.FlutterBridge
 import io.rebble.cobble.pigeons.Pigeons
-import io.rebble.cobble.pigeons.Pigeons.AppReorderRequest
 import io.rebble.cobble.util.awaitPigeonMethod
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,17 +35,6 @@ class BackgroundAppInstallBridge @Inject constructor(
         }
 
         return true
-    }
-
-    suspend fun beginAppOrderChange(reorderRequest: AppReorderRequest): Boolean {
-        val appInstallCallbacks = getAppInstallCallbacks() ?: return false
-
-        awaitPigeonMethod<Void> { reply ->
-            appInstallCallbacks.beginAppOrderChange(reorderRequest, reply)
-        }
-
-        return true
-
     }
 
     private suspend fun getAppInstallCallbacks(): Pigeons.BackgroundAppInstallCallbacks? {

--- a/android/app/src/main/kotlin/io/rebble/cobble/bridges/background/CalendarFlutterBridge.kt
+++ b/android/app/src/main/kotlin/io/rebble/cobble/bridges/background/CalendarFlutterBridge.kt
@@ -24,17 +24,6 @@ class CalendarFlutterBridge @Inject constructor(
         return true
     }
 
-    suspend fun deleteCalendarPinsFromWatch(): Boolean {
-        val calendarCallbacks = getCalendarCallbacks() ?: return false
-        suspendCoroutine<Unit> { continuation ->
-            calendarCallbacks.deleteCalendarPinsFromWatch {
-                continuation.resume(Unit)
-            }
-        }
-
-        return true
-    }
-
     private suspend fun getCalendarCallbacks(): Pigeons.CalendarCallbacks? {
         val cachedCalendarCallbacks = cachedCalendarCallbacks
         if (cachedCalendarCallbacks != null) {

--- a/android/app/src/main/kotlin/io/rebble/cobble/bridges/common/AppInstallFlutterBridge.kt
+++ b/android/app/src/main/kotlin/io/rebble/cobble/bridges/common/AppInstallFlutterBridge.kt
@@ -257,16 +257,6 @@ class AppInstallFlutterBridge @Inject constructor(
         }
     }
 
-    override fun beginAppOrderChange(
-            reorderRequest: Pigeons.AppReorderRequest,
-            result: Pigeons.Result<Pigeons.NumberWrapper>
-    ) {
-        coroutineScope.launchPigeonResult(result) {
-            backgroundAppInstallBridge.beginAppOrderChange(reorderRequest)
-            NumberWrapper(1)
-        }
-    }
-
     override fun subscribeToAppStatus() {
         statusObservingJob = coroutineScope.launch {
             putBytesController.status.collect {

--- a/android/app/src/main/kotlin/io/rebble/cobble/bridges/ui/BackgroundSetupFlutterBridge.kt
+++ b/android/app/src/main/kotlin/io/rebble/cobble/bridges/ui/BackgroundSetupFlutterBridge.kt
@@ -1,13 +1,18 @@
 package io.rebble.cobble.bridges.ui
 
 import io.rebble.cobble.bridges.FlutterBridge
+import io.rebble.cobble.bridges.background.FlutterBackgroundController
 import io.rebble.cobble.datasources.AndroidPreferences
 import io.rebble.cobble.pigeons.Pigeons
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class BackgroundSetupFlutterBridge @Inject constructor(
         bridgeLifecycleController: BridgeLifecycleController,
-        private val androidPreferences: AndroidPreferences
+        private val androidPreferences: AndroidPreferences,
+        private val flutterBackgroundController: FlutterBackgroundController
 ) : FlutterBridge, Pigeons.BackgroundSetupControl {
     init {
         bridgeLifecycleController.setupControl(Pigeons.BackgroundSetupControl::setup, this)
@@ -15,6 +20,10 @@ class BackgroundSetupFlutterBridge @Inject constructor(
 
     override fun setupBackground(arg: Pigeons.NumberWrapper) {
         androidPreferences.backgroundEndpoint = arg.value
+
+        GlobalScope.launch(Dispatchers.Main.immediate) {
+            flutterBackgroundController.getBackgroundFlutterEngine()
+        }
     }
 
 }

--- a/android/app/src/main/kotlin/io/rebble/cobble/bridges/ui/CalendarControlFlutterBridge.kt
+++ b/android/app/src/main/kotlin/io/rebble/cobble/bridges/ui/CalendarControlFlutterBridge.kt
@@ -38,10 +38,4 @@ class CalendarControlFlutterBridge @Inject constructor(
             calendarFlutterBridge.syncCalendar()
         }
     }
-
-    override fun deleteCalendarPinsFromWatch() {
-        coroutineScope.launch {
-            calendarFlutterBridge.deleteCalendarPinsFromWatch()
-        }
-    }
 }

--- a/lib/background/main_background.dart
+++ b/lib/background/main_background.dart
@@ -3,6 +3,7 @@ import 'package:cobble/background/modules/notifications_background.dart';
 import 'package:cobble/domain/connection/connection_state_provider.dart';
 import 'package:cobble/domain/entities/pebble_device.dart';
 import 'package:cobble/domain/logging.dart';
+import 'package:cobble/infrastructure/backgroundcomm/BackgroundReceiver.dart';
 import 'package:cobble/infrastructure/datasources/preferences.dart';
 import 'package:cobble/infrastructure/pigeons/pigeons.g.dart';
 import 'package:cobble/localization/localization.dart';
@@ -72,6 +73,8 @@ class BackgroundReceiver implements TimelineCallbacks {
     notificationsBackground.init();
     appsBackground = AppsBackground(this.container);
     appsBackground.init();
+
+    startReceivingRpcRequests(onMessageFromUi);
   }
 
   void onWatchConnected(PebbleDevice watch) async {
@@ -105,6 +108,17 @@ class BackgroundReceiver implements TimelineCallbacks {
     if (success) {
       prefs.setLastConnectedWatchAddress(watch.address!);
     }
+  }
+
+  Future<Object> onMessageFromUi(Object message) async {
+    Object? result;
+
+    result = appsBackground.onMessageFromUi(message);
+    if (result != null) {
+      return result;
+    }
+
+    throw Exception("Unknown message $message");
   }
 
   Future syncTimelineToWatch() async {

--- a/lib/background/main_background.dart
+++ b/lib/background/main_background.dart
@@ -118,6 +118,11 @@ class BackgroundReceiver implements TimelineCallbacks {
       return result;
     }
 
+    result = calendarBackground.onMessageFromUi(message);
+    if (result != null) {
+      return result;
+    }
+
     throw Exception("Unknown message $message");
   }
 

--- a/lib/background/modules/calendar_background.dart
+++ b/lib/background/modules/calendar_background.dart
@@ -1,5 +1,6 @@
 import 'package:cobble/domain/calendar/calendar_pin_convert.dart';
 import 'package:cobble/domain/calendar/calendar_syncer.db.dart';
+import 'package:cobble/domain/calendar/requests/delete_all_pins_request.dart';
 import 'package:cobble/domain/connection/connection_state_provider.dart';
 import 'package:cobble/domain/db/dao/timeline_pin_dao.dart';
 import 'package:cobble/domain/entities/pebble_device.dart';
@@ -41,10 +42,19 @@ class CalendarBackground implements CalendarCallbacks {
     }
   }
 
-  @override
-  Future<void> deleteCalendarPinsFromWatch() async {
+  Future<Object>? onMessageFromUi(Object message) {
+    if (message is DeleteAllCalendarPinsRequest) {
+      return deleteCalendarPinsFromWatch();
+    }
+
+    return null;
+  }
+
+  Future<bool> deleteCalendarPinsFromWatch() async {
     await timelinePinDao.markAllPinsFromAppForDeletion(calendarWatchappId);
     await syncTimelineToWatch();
+
+    return true;
   }
 
   @override

--- a/lib/domain/apps/app_manager.dart
+++ b/lib/domain/apps/app_manager.dart
@@ -1,15 +1,19 @@
 import 'package:cobble/domain/db/dao/app_dao.dart';
+import 'package:cobble/infrastructure/backgroundcomm/BackgroundRpc.dart';
 import 'package:cobble/infrastructure/pigeons/pigeons.g.dart';
+import 'package:cobble/util/async_value_extensions.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:uuid_type/uuid_type.dart';
 
 import '../db/models/app.dart';
+import 'requests/app_reorder_request.dart';
 
 class AppManager extends StateNotifier<List<App>> {
   final appInstallControl = AppInstallControl();
   final AppDao appDao;
+  final BackgroundRpc backgroundRpc;
 
-  AppManager(this.appDao) : super(List.empty()) {
+  AppManager(this.appDao, this.backgroundRpc) : super(List.empty()) {
     refresh();
   }
 
@@ -35,16 +39,17 @@ class AppManager extends StateNotifier<List<App>> {
   }
 
   Future<void> reorderApp(Uuid uuid, int newPosition) async {
-    final request = AppReorderRequest();
-    request.uuid = uuid.toString();
-    request.newPosition = newPosition;
+    final request = AppReorderRequest(uuid, newPosition);
 
-    await appInstallControl.beginAppOrderChange(request);
+    final result = await backgroundRpc.triggerMethod(request);
+    result.resultOrThrow();
+
     await refresh();
   }
 }
 
 final appManagerProvider = AutoDisposeStateNotifierProvider<AppManager>((ref) {
   final dao = ref.watch(appDaoProvider);
-  return AppManager(dao);
+  final rpc = ref.read(backgroundRpcProvider);
+  return AppManager(dao, rpc);
 });

--- a/lib/domain/apps/requests/app_reorder_request.dart
+++ b/lib/domain/apps/requests/app_reorder_request.dart
@@ -1,0 +1,8 @@
+import 'package:uuid_type/uuid_type.dart';
+
+class AppReorderRequest {
+  final Uuid uuid;
+  final int newPosition;
+
+  AppReorderRequest(this.uuid, this.newPosition);
+}

--- a/lib/domain/calendar/requests/delete_all_pins_request.dart
+++ b/lib/domain/calendar/requests/delete_all_pins_request.dart
@@ -1,0 +1,1 @@
+class DeleteAllCalendarPinsRequest {}

--- a/lib/infrastructure/backgroundcomm/BackgroundReceiver.dart
+++ b/lib/infrastructure/backgroundcomm/BackgroundReceiver.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:cobble/infrastructure/backgroundcomm/RpcRequest.dart';
+import 'package:cobble/infrastructure/backgroundcomm/RpcResult.dart';
+
+import 'BackgroundRpc.dart';
+
+typedef ReceivingFunction = Future<Object> Function(Object input);
+
+void startReceivingRpcRequests(ReceivingFunction receivingFunction) {
+  final receivingPort = ReceivePort();
+  IsolateNameServer.registerPortWithName(
+    receivingPort.sendPort,
+    isolatePortNameToBackground,
+  );
+
+  receivingPort.listen((message) {
+    Future.microtask(() async {
+      if (message is! RpcRequest) {
+        throw Exception("Message is not RpcRequest: $message");
+      }
+
+      final request = message as RpcRequest;
+
+      RpcResult result;
+      try {
+        final resultObject = await receivingFunction(request.input);
+        result = RpcResult.success(request.requestId, resultObject);
+      } catch (e, stackTrace) {
+        print(e);
+        result = RpcResult.error(request.requestId, e, stackTrace);
+      }
+
+      final returnPort = IsolateNameServer.lookupPortByName(
+        isolatePortNameReturnFromBackground,
+      );
+
+      if (returnPort != null) {
+        returnPort.send(result);
+      }
+
+      // If returnPort is null, then receiver died and
+      // does not care about the result anymore. Just drop it.
+    });
+  });
+}

--- a/lib/infrastructure/backgroundcomm/BackgroundReceiver.dart
+++ b/lib/infrastructure/backgroundcomm/BackgroundReceiver.dart
@@ -11,6 +11,7 @@ typedef ReceivingFunction = Future<Object> Function(Object input);
 
 void startReceivingRpcRequests(ReceivingFunction receivingFunction) {
   final receivingPort = ReceivePort();
+  IsolateNameServer.removePortNameMapping(isolatePortNameToBackground);
   IsolateNameServer.registerPortWithName(
     receivingPort.sendPort,
     isolatePortNameToBackground,

--- a/lib/infrastructure/backgroundcomm/BackgroundRpc.dart
+++ b/lib/infrastructure/backgroundcomm/BackgroundRpc.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:cobble/domain/logging.dart';
+import 'package:cobble/infrastructure/backgroundcomm/RpcRequest.dart';
+import 'package:cobble/infrastructure/backgroundcomm/RpcResult.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Helper class for triggering methods on the background flutter side.
+///
+/// System works by sending a specific object as an input. Then based on the
+/// object you send, background will execute target method and return result.
+///
+/// This class never returns AsyncValue.loading (only data or error).
+class BackgroundRpc {
+  Map<int, Completer<AsyncValue<Object>>> _pendingCompleters = Map();
+  int _nextMessageId = 0;
+
+  BackgroundRpc() {
+    _startReceivingResults();
+  }
+
+  Future<AsyncValue<O>> triggerMethod<I extends Object, O extends Object>(
+    I input,
+  ) async {
+    final port = IsolateNameServer.lookupPortByName(
+      isolatePortNameToBackground,
+    );
+
+    if (port == null) {
+      throw Exception("Port not open. Is background running?");
+    }
+
+    final requestId = _nextMessageId++;
+
+    final request = RpcRequest(requestId, input);
+
+    final completer = Completer<AsyncValue<Object>>();
+    _pendingCompleters[requestId] = completer;
+
+    port.send(request);
+
+    final result = await completer.future;
+    return result as AsyncValue<O>;
+  }
+
+  void _startReceivingResults() {
+    final returnPort = ReceivePort();
+    IsolateNameServer.registerPortWithName(
+        returnPort.sendPort, isolatePortNameReturnFromBackground);
+
+    returnPort.listen((message) {
+      if (message is! RpcResult) {
+        Log.e("Unknown message: $message");
+        return;
+      }
+
+      final receivedMessage = message as RpcResult;
+      final waitingCompleter = _pendingCompleters[receivedMessage.id];
+      if (waitingCompleter == null) {
+        return;
+      }
+
+      AsyncValue<Object> result;
+
+      if (receivedMessage.successResult != null) {
+        result = AsyncValue.data(receivedMessage.successResult!);
+      } else if (receivedMessage.errorResult != null) {
+        result = AsyncValue.error(
+          receivedMessage.errorResult!,
+          receivedMessage.errorStacktrace,
+        );
+      } else {
+        result = AsyncValue.error("Received result without any data.");
+      }
+
+      waitingCompleter.complete(result);
+    });
+  }
+}
+
+final String isolatePortNameToBackground = "toBackground";
+final String isolatePortNameReturnFromBackground = "returnFromBackground";
+
+final backgroundRpcProvider = Provider<BackgroundRpc>((ref) => BackgroundRpc());

--- a/lib/infrastructure/backgroundcomm/BackgroundRpc.dart
+++ b/lib/infrastructure/backgroundcomm/BackgroundRpc.dart
@@ -47,6 +47,8 @@ class BackgroundRpc {
 
   void _startReceivingResults() {
     final returnPort = ReceivePort();
+    IsolateNameServer.removePortNameMapping(
+        isolatePortNameReturnFromBackground);
     IsolateNameServer.registerPortWithName(
         returnPort.sendPort, isolatePortNameReturnFromBackground);
 

--- a/lib/infrastructure/backgroundcomm/RpcRequest.dart
+++ b/lib/infrastructure/backgroundcomm/RpcRequest.dart
@@ -1,0 +1,11 @@
+class RpcRequest {
+  final int requestId;
+  final Object input;
+
+  RpcRequest(this.requestId, this.input);
+
+  @override
+  String toString() {
+    return 'RpcRequest{requestId: $requestId, input: $input}';
+  }
+}

--- a/lib/infrastructure/backgroundcomm/RpcResult.dart
+++ b/lib/infrastructure/backgroundcomm/RpcResult.dart
@@ -1,0 +1,25 @@
+class RpcResult {
+  final int id;
+  final Object? successResult;
+  final Object? errorResult;
+  final StackTrace? errorStacktrace;
+
+  RpcResult(
+      this.id, this.successResult, this.errorResult, this.errorStacktrace);
+
+  @override
+  String toString() {
+    return 'RpcResult{id: $id, '
+        'successResult: $successResult, '
+        'errorResult: $errorResult,'
+        ' errorStacktrace: $errorStacktrace}';
+  }
+
+  static RpcResult success(int id, Object result) {
+    return RpcResult(id, result, null, null);
+  }
+
+  static RpcResult error(int id, Object errorResult, StackTrace? stackTrace) {
+    return RpcResult(id, null, errorResult, stackTrace);
+  }
+}

--- a/lib/infrastructure/pigeons/pigeons.g.dart
+++ b/lib/infrastructure/pigeons/pigeons.g.dart
@@ -1195,7 +1195,6 @@ class DebugControl {
 
 abstract class CalendarCallbacks {
   Future<void> doFullCalendarSync();
-  Future<void> deleteCalendarPinsFromWatch();
   static void setup(CalendarCallbacks api) {
     {
       const BasicMessageChannel<Object> channel =
@@ -1206,19 +1205,6 @@ abstract class CalendarCallbacks {
         channel.setMessageHandler((Object message) async {
           // ignore message
           await api.doFullCalendarSync();
-          return;
-        });
-      }
-    }
-    {
-      const BasicMessageChannel<Object> channel =
-          BasicMessageChannel<Object>('dev.flutter.pigeon.CalendarCallbacks.deleteCalendarPinsFromWatch', StandardMessageCodec());
-      if (api == null) {
-        channel.setMessageHandler(null);
-      } else {
-        channel.setMessageHandler((Object message) async {
-          // ignore message
-          await api.deleteCalendarPinsFromWatch();
           return;
         });
       }
@@ -2083,28 +2069,6 @@ class CalendarControl {
   Future<void> requestCalendarSync() async {
     const BasicMessageChannel<Object> channel =
         BasicMessageChannel<Object>('dev.flutter.pigeon.CalendarControl.requestCalendarSync', StandardMessageCodec());
-    final Map<Object, Object> replyMap = await channel.send(null) as Map<Object, Object>;
-    if (replyMap == null) {
-      throw PlatformException(
-        code: 'channel-error',
-        message: 'Unable to establish connection on channel.',
-        details: null,
-      );
-    } else if (replyMap['error'] != null) {
-      final Map<Object, Object> error = replyMap['error'] as Map<Object, Object>;
-      throw PlatformException(
-        code: error['code'] as String,
-        message: error['message'] as String,
-        details: error['details'],
-      );
-    } else {
-      // noop
-    }
-  }
-
-  Future<void> deleteCalendarPinsFromWatch() async {
-    const BasicMessageChannel<Object> channel =
-        BasicMessageChannel<Object>('dev.flutter.pigeon.CalendarControl.deleteCalendarPinsFromWatch', StandardMessageCodec());
     final Map<Object, Object> replyMap = await channel.send(null) as Map<Object, Object>;
     if (replyMap == null) {
       throw PlatformException(

--- a/lib/infrastructure/pigeons/pigeons.g.dart
+++ b/lib/infrastructure/pigeons/pigeons.g.dart
@@ -470,25 +470,6 @@ class WatchappInfo {
   }
 }
 
-class AppReorderRequest {
-  String uuid;
-  int newPosition;
-
-  Object encode() {
-    final Map<Object, Object> pigeonMap = <Object, Object>{};
-    pigeonMap['uuid'] = uuid;
-    pigeonMap['newPosition'] = newPosition;
-    return pigeonMap;
-  }
-
-  static AppReorderRequest decode(Object message) {
-    final Map<Object, Object> pigeonMap = message as Map<Object, Object>;
-    return AppReorderRequest()
-      ..uuid = pigeonMap['uuid'] as String
-      ..newPosition = pigeonMap['newPosition'] as int;
-  }
-}
-
 class AppEntriesPigeon {
   List<Object> appName;
   List<Object> packageId;
@@ -859,11 +840,8 @@ class AppLogControl {
 
 abstract class ScanCallbacks {
   void onScanUpdate(ListWrapper arg);
-
   void onScanStarted();
-
   void onScanStopped();
-
   static void setup(ScanCallbacks api) {
     {
       const BasicMessageChannel<Object> channel = BasicMessageChannel<Object>(
@@ -1518,7 +1496,6 @@ class PermissionControl {
 
 abstract class AppLogCallbacks {
   void onLogReceived(AppLogEntry arg);
-
   static void setup(AppLogCallbacks api) {
     {
       const BasicMessageChannel<Object> channel = BasicMessageChannel<Object>(
@@ -1682,7 +1659,6 @@ class NotificationsControl {
 abstract class BackgroundAppInstallCallbacks {
   Future<void> beginAppInstall(InstallData arg);
   Future<void> deleteApp(StringWrapper arg);
-  Future<void> beginAppOrderChange(AppReorderRequest arg);
   static void setup(BackgroundAppInstallCallbacks api) {
     {
       const BasicMessageChannel<Object> channel =
@@ -1708,20 +1684,6 @@ abstract class BackgroundAppInstallCallbacks {
           assert(message != null, 'Argument for dev.flutter.pigeon.BackgroundAppInstallCallbacks.deleteApp was null. Expected StringWrapper.');
           final StringWrapper input = StringWrapper.decode(message);
           await api.deleteApp(input);
-          return;
-        });
-      }
-    }
-    {
-      const BasicMessageChannel<Object> channel =
-          BasicMessageChannel<Object>('dev.flutter.pigeon.BackgroundAppInstallCallbacks.beginAppOrderChange', StandardMessageCodec());
-      if (api == null) {
-        channel.setMessageHandler(null);
-      } else {
-        channel.setMessageHandler((Object message) async {
-          assert(message != null, 'Argument for dev.flutter.pigeon.BackgroundAppInstallCallbacks.beginAppOrderChange was null. Expected AppReorderRequest.');
-          final AppReorderRequest input = AppReorderRequest.decode(message);
-          await api.beginAppOrderChange(input);
           return;
         });
       }
@@ -1849,29 +1811,6 @@ class AppInstallControl {
     const BasicMessageChannel<Object> channel =
         BasicMessageChannel<Object>('dev.flutter.pigeon.AppInstallControl.removeAllApps', StandardMessageCodec());
     final Map<Object, Object> replyMap = await channel.send(null) as Map<Object, Object>;
-    if (replyMap == null) {
-      throw PlatformException(
-        code: 'channel-error',
-        message: 'Unable to establish connection on channel.',
-        details: null,
-      );
-    } else if (replyMap['error'] != null) {
-      final Map<Object, Object> error = replyMap['error'] as Map<Object, Object>;
-      throw PlatformException(
-        code: error['code'] as String,
-        message: error['message'] as String,
-        details: error['details'],
-      );
-    } else {
-      return NumberWrapper.decode(replyMap['result']);
-    }
-  }
-
-  Future<NumberWrapper> beginAppOrderChange(AppReorderRequest arg) async {
-    final Object encoded = arg.encode();
-    const BasicMessageChannel<Object> channel =
-        BasicMessageChannel<Object>('dev.flutter.pigeon.AppInstallControl.beginAppOrderChange', StandardMessageCodec());
-    final Map<Object, Object> replyMap = await channel.send(encoded) as Map<Object, Object>;
     if (replyMap == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/lib/ui/screens/calendar.dart
+++ b/lib/ui/screens/calendar.dart
@@ -1,16 +1,18 @@
-import 'package:cobble/localization/localization.dart';
-import 'package:cobble/ui/common/components/cobble_tile.dart';
-import 'package:cobble/ui/common/components/cobble_divider.dart';
-import 'package:cobble/ui/common/icons/fonts/rebble_icons.dart';
 import 'package:cobble/domain/calendar/calendar_list.dart';
-import 'package:cobble/infrastructure/datasources/preferences.dart';
 import 'package:cobble/domain/calendar/device_calendar_plugin_provider.dart';
+import 'package:cobble/domain/calendar/requests/delete_all_pins_request.dart';
+import 'package:cobble/domain/permissions.dart';
+import 'package:cobble/infrastructure/backgroundcomm/BackgroundRpc.dart';
+import 'package:cobble/infrastructure/datasources/preferences.dart';
+import 'package:cobble/localization/localization.dart';
+import 'package:cobble/ui/common/components/cobble_divider.dart';
+import 'package:cobble/ui/common/components/cobble_tile.dart';
+import 'package:cobble/ui/common/icons/fonts/rebble_icons.dart';
 import 'package:cobble/ui/router/cobble_scaffold.dart';
 import 'package:cobble/ui/router/cobble_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:cobble/domain/permissions.dart';
 
 class Calendar extends HookWidget implements CobbleScreen {
 
@@ -19,12 +21,13 @@ class Calendar extends HookWidget implements CobbleScreen {
     final calendars = useProvider(calendarListProvider.state);
     final calendarSelector = useProvider(calendarListProvider);
     final calendarControl = useProvider(calendarControlProvider);
-  
+    final backgroundRpc = useProvider(backgroundRpcProvider);
+
     final preferences = useProvider(preferencesProvider);
     final calendarSyncEnabled = useProvider(calendarSyncEnabledProvider);
     final permissionControl = useProvider(permissionControlProvider);
     final permissionCheck = useProvider(permissionCheckProvider);
-    
+
     useEffect(() {
       Future.microtask(() async {
         if (!(await permissionCheck.hasCalendarPermission()).value!) {
@@ -33,7 +36,7 @@ class Calendar extends HookWidget implements CobbleScreen {
       });
       return null;
     }, ["one-time"]);
-    
+
     return CobbleScaffold.tab(
       title: tr.calendar.title,
       child: ListView(
@@ -48,7 +51,7 @@ class Calendar extends HookWidget implements CobbleScreen {
                 await preferences.data?.value.setCalendarSyncEnabled(value);
 
                 if (!value) {
-                  calendarControl.deleteCalendarPinsFromWatch();
+                  backgroundRpc.triggerMethod(DeleteAllCalendarPinsRequest());
                 }
               },
             ),
@@ -64,17 +67,17 @@ class Calendar extends HookWidget implements CobbleScreen {
                   color: Color(e.color).withOpacity(1),
                   shape: BoxShape.circle,
                 ),
-                title: e.name,
-                child: Checkbox(
-                  value: e.enabled,
-                  onChanged: (enabled) {
-                    calendarSelector.setCalendarEnabled(e.id, enabled!);
-                    calendarControl.requestCalendarSync();
-                  },
-                ),
-              );
-            }).toList() ??
-            [],
+                    title: e.name,
+                    child: Checkbox(
+                      value: e.enabled,
+                      onChanged: (enabled) {
+                        calendarSelector.setCalendarEnabled(e.id, enabled!);
+                        calendarControl.requestCalendarSync();
+                      },
+                    ),
+                  );
+                }).toList() ??
+                [],
           ],
         ],
       ),

--- a/lib/util/async_value_extensions.dart
+++ b/lib/util/async_value_extensions.dart
@@ -1,0 +1,13 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+extension AsyncValueExtension<T> on AsyncValue<T> {
+  T? resultOrThrow() {
+    if (this is AsyncData<T>) {
+      return (this as AsyncData<T>).value;
+    } else if (this is AsyncError<T>) {
+      throw (this as AsyncError<T>).error;
+    } else {
+      throw Exception("Value is still loading");
+    }
+  }
+}

--- a/pigeons/pigeons.dart
+++ b/pigeons/pigeons.dart
@@ -153,13 +153,6 @@ class AppInstallStatus {
   AppInstallStatus(this.progress, this.isInstalling);
 }
 
-class AppReorderRequest {
-  String uuid;
-  int newPosition;
-
-  AppReorderRequest(this.uuid, this.newPosition);
-}
-
 class ScreenshotResult {
   bool success;
   String? imagePath;
@@ -228,9 +221,6 @@ abstract class BackgroundAppInstallCallbacks {
 
   @async
   void deleteApp(StringWrapper uuid);
-
-  @async
-  void beginAppOrderChange(AppReorderRequest appReorderRequest);
 }
 
 @FlutterApi()
@@ -421,9 +411,6 @@ abstract class AppInstallControl {
 
   @async
   NumberWrapper removeAllApps();
-
-  @async
-  NumberWrapper beginAppOrderChange(AppReorderRequest appReorderRequest);
 
   void subscribeToAppStatus();
 

--- a/pigeons/pigeons.dart
+++ b/pigeons/pigeons.dart
@@ -386,11 +386,13 @@ abstract class AppInstallControl {
   @async
   PbwAppInfo getAppInfo(StringWrapper localPbwUri);
 
-  // Just relay method that triggers beginAppInstall on background flutter side
+  // Just relay method that triggers copies the app into local storage and
+  // begins install on the background flutter side
   @async
   BooleanWrapper beginAppInstall(InstallData installData);
 
-  // Just relay method that triggers deleteApp on background flutter side
+  // Just relay method that deletes app from the local store and triggers
+  // deleteApp on background flutter side
   // Return BooleanWrapper as a
   // workaround for https://github.com/flutter/flutter/issues/78536
   @async

--- a/pigeons/pigeons.dart
+++ b/pigeons/pigeons.dart
@@ -196,9 +196,6 @@ abstract class PairCallbacks {
 abstract class CalendarCallbacks {
   @async
   void doFullCalendarSync();
-
-  @async
-  void deleteCalendarPinsFromWatch();
 }
 
 @FlutterApi()
@@ -358,8 +355,6 @@ abstract class PermissionControl {
 @HostApi()
 abstract class CalendarControl {
   void requestCalendarSync();
-
-  void deleteCalendarPinsFromWatch();
 }
 
 @HostApi()


### PR DESCRIPTION
Until now, to send any commands from UI flutter to background flutter, you had to send a message to the native, which relayed the message to the background.

This was very boilerplate-y and annoying (dealing with pigeon). New system opens direct Send/Receive port between the two with the help of the `IsolateNameServer` and then sends direct objects back and forth.