### PR TITLE
Fix cut-off appbar in about screen

### DIFF
--- a/lib/ui/screens/about.dart
+++ b/lib/ui/screens/about.dart
@@ -33,6 +33,7 @@ class About extends HookWidget implements CobbleScreen {
 
     return CobbleScaffold.tab(
       title: " ", // We want an empty appbar
+      expandedAppBar: true,
       bottomAppBar: PreferredSize(
         preferredSize: const Size.fromHeight(156.0),
         child: Container(


### PR DESCRIPTION
The appbar now requires expandedAppBar settings to be set to true in the scenario that previously didn't require it, but about page wasn't updated for that, this fixes it.