### PR TITLE
Fix boot URL override behavior

### DIFF
--- a/lib/infrastructure/datasources/preferences.dart
+++ b/lib/infrastructure/datasources/preferences.dart
@@ -22,29 +22,32 @@ class Preferences {
   }
 
   String? getBoot() {
+    if (shouldOverrideBoot() == true) {
+      return getOverrideBootValue();
+    }
     return _sharedPrefs.getString("boot");
   }
 
   Future<void> setBoot(String value) async {
-    await _sharedPrefs.setString("overrideBoot", value);
+    await _sharedPrefs.setString("boot", value);
     _preferencesUpdateStream.add(this);
   }
 
   bool? shouldOverrideBoot() {
-    return _sharedPrefs.getBool("overrideBoot");
+    return _sharedPrefs.getBool("shouldOverrideBoot");
   }
 
   Future<void> setShouldOverrideBoot(bool value) async {
-    await _sharedPrefs.setBool("overrideBoot", value);
+    await _sharedPrefs.setBool("shouldOverrideBoot", value);
     _preferencesUpdateStream.add(this);
   }
 
   String? getOverrideBootValue() {
-    return _sharedPrefs.getString("overrideBoot");
+    return _sharedPrefs.getString("bootOverrideUrl");
   }
 
   Future<void> setOverrideBootValue(String value) async {
-    await _sharedPrefs.setString("boot", value);
+    await _sharedPrefs.setString("bootOverrideUrl", value);
     _preferencesUpdateStream.add(this);
   }
 

--- a/lib/ui/devoptions/dev_options_page.dart
+++ b/lib/ui/devoptions/dev_options_page.dart
@@ -72,15 +72,13 @@ class DevOptionsPage extends HookWidget implements CobbleScreen {
             title: Text("URL"),
             subtitle: TextField(
               controller: bootUrlController,
-              onChanged: (value) {
-                preferences.whenData((prefs) => prefs.setBoot(value));
-              },
+              readOnly: true,
             ),
           ),
           SwitchListTile(
               value: shouldOverrideBoot,
-              title: Text("Override stage2 config"),
-              subtitle: Text("If enabled, will ignore boot URL"),
+              title: Text("Override boot URL"),
+              subtitle: Text("If enabled, will use the override boot URL instead of the main boot URL"),
               onChanged: (value) {
                 preferences
                     .whenData((prefs) => prefs.setShouldOverrideBoot(value));


### PR DESCRIPTION
The previous behavior didn't make much sense (it even tried to use a single shared preferences value as both a boolean and a string), and it made it easy to overwrite your rebble token. This PR makes it so that when you call `getBoot()`, the correct boot URL is returned based on the value of `shouldOverrideBoot`, and makes it so that you cannot manually delete the boot URL provided from the Rebble webpage.