### PR TITLE
Update riverpod to 0.14.0

### DIFF
--- a/lib/background/actions/calendar_action_handler.dart
+++ b/lib/background/actions/calendar_action_handler.dart
@@ -21,7 +21,7 @@ import 'package:cobble/util/state_provider_extension.dart';
 import 'package:cobble/util/stream_extensions.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:device_calendar/device_calendar.dart';
-import 'package:hooks_riverpod/all.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class CalendarActionHandler implements ActionHandler {
   final TimelinePinDao _dao;
@@ -217,6 +217,6 @@ final calendarActionHandlerProvider = Provider((ref) =>
       ref.read(timelinePinDaoProvider),
       ref.read(calendarSyncerProvider),
       ref.read(watchTimelineSyncerProvider),
-      ref.read(calendarListProvider),
+      ref.read(calendarListProvider.notifier),
       ref.read(deviceCalendarPluginProvider),
     ));

--- a/lib/background/main_background.dart
+++ b/lib/background/main_background.dart
@@ -49,7 +49,7 @@ class BackgroundReceiver implements TimelineCallbacks {
     masterActionHandler = container.read(masterActionHandlerProvider);
 
     connectionSubscription = container.listen(
-      connectionStateProvider.state,
+      connectionStateProvider,
       mayHaveChanged: (sub) {
         final currentConnectedWatch = sub.read().currentConnectedWatch;
         if (isConnectedToWatch()! && currentConnectedWatch!.name!.isNotEmpty) {

--- a/lib/background/modules/apps_background.dart
+++ b/lib/background/modules/apps_background.dart
@@ -34,7 +34,7 @@ class AppsBackground implements BackgroundAppInstallCallbacks {
     BackgroundAppInstallCallbacks.setup(this);
 
     connectionSubscription = container.listen(
-      connectionStateProvider.state,
+      connectionStateProvider,
     );
   }
 

--- a/lib/background/modules/calendar_background.dart
+++ b/lib/background/modules/calendar_background.dart
@@ -28,7 +28,7 @@ class CalendarBackground implements CalendarCallbacks {
     CalendarCallbacks.setup(this);
 
     connectionSubscription = container.listen(
-      connectionStateProvider.state,
+      connectionStateProvider,
     );
   }
 

--- a/lib/domain/apps/app_install_status.dart
+++ b/lib/domain/apps/app_install_status.dart
@@ -29,7 +29,7 @@ AppInstallStatus _getDefault() {
 }
 
 final appInstallStatusProvider =
-    AutoDisposeStateNotifierProvider<AppInstallStatusStateNotifier>((ref) {
+    AutoDisposeStateNotifierProvider<AppInstallStatusStateNotifier, AppInstallStatus>((ref) {
   final notifier = AppInstallStatusStateNotifier();
 
   ref.onDispose(() {

--- a/lib/domain/apps/app_manager.dart
+++ b/lib/domain/apps/app_manager.dart
@@ -64,7 +64,7 @@ class AppManager extends StateNotifier<List<App>> {
   }
 }
 
-final appManagerProvider = AutoDisposeStateNotifierProvider<AppManager>((ref) {
+final appManagerProvider = AutoDisposeStateNotifierProvider<AppManager, List<App>>((ref) {
   final dao = ref.watch(appDaoProvider);
   final rpc = ref.read(backgroundRpcProvider);
   return AppManager(dao, rpc);

--- a/lib/domain/calendar/calendar_list.dart
+++ b/lib/domain/calendar/calendar_list.dart
@@ -72,8 +72,8 @@ class CalendarList extends StateNotifier<AsyncValue<List<SelectableCalendar>>> {
   }
 }
 
-final AutoDisposeStateNotifierProvider<CalendarList> calendarListProvider =
-    StateNotifierProvider.autoDispose<CalendarList>((ref) {
+final AutoDisposeStateNotifierProvider<CalendarList, AsyncValue<List<SelectableCalendar>>> calendarListProvider =
+    StateNotifierProvider.autoDispose<CalendarList, AsyncValue<List<SelectableCalendar>>>((ref) {
   // Use auto-dispose to ensure calendar list is reloaded every time user
   // re-opens the screen since we cannot propagate change notifications
   // between background and UI isolate

--- a/lib/domain/calendar/calendar_syncer.db.dart
+++ b/lib/domain/calendar/calendar_syncer.db.dart
@@ -139,7 +139,7 @@ class _EventInCalendar {
 
 final AutoDisposeProvider<CalendarSyncer> calendarSyncerProvider =
     Provider.autoDispose<CalendarSyncer>((ref) {
-  final calendarList = ref.watch(calendarListProvider);
+  final calendarList = ref.watch(calendarListProvider.notifier);
   final deviceCalendar = ref.watch(deviceCalendarPluginProvider);
   final dateTimeProvider = ref.watch(currentDateTimeProvider);
   final timelinePinDao = ref.watch(timelinePinDaoProvider);

--- a/lib/domain/connection/connection_state_provider.dart
+++ b/lib/domain/connection/connection_state_provider.dart
@@ -37,9 +37,9 @@ class ConnectionCallbacksStateNotifier
   }
 }
 
-final AutoDisposeStateNotifierProvider<ConnectionCallbacksStateNotifier>
+final AutoDisposeStateNotifierProvider<ConnectionCallbacksStateNotifier, WatchConnectionState>
     connectionStateProvider =
-    StateNotifierProvider.autoDispose<ConnectionCallbacksStateNotifier>((ref) {
+    StateNotifierProvider.autoDispose<ConnectionCallbacksStateNotifier, WatchConnectionState>((ref) {
   final notifier = ConnectionCallbacksStateNotifier();
   ref.onDispose(notifier.dispose);
   return notifier;

--- a/lib/domain/connection/scan_provider.dart
+++ b/lib/domain/connection/scan_provider.dart
@@ -1,6 +1,6 @@
 import 'package:cobble/domain/entities/pebble_scan_device.dart';
 import 'package:cobble/infrastructure/pigeons/pigeons.g.dart' as pigeon;
-import 'package:hooks_riverpod/all.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Stores state of current scan operation. Devices can be empty array but
 /// will never be null.
@@ -40,7 +40,7 @@ class ScanCallbacks extends StateNotifier<ScanState>
   }
 }
 
-final scanProvider = StateNotifierProvider<ScanCallbacks>((ref) {
+final scanProvider = StateNotifierProvider<ScanCallbacks, ScanState>((ref) {
   final notifier = ScanCallbacks();
   pigeon.ScanCallbacks.setup(notifier);
   ref.onDispose(() {

--- a/lib/domain/timeline/watch_apps_syncer.dart
+++ b/lib/domain/timeline/watch_apps_syncer.dart
@@ -146,7 +146,7 @@ final AutoDisposeProvider<WatchAppsSyncer> watchAppSyncerProvider =
 Provider.autoDispose<WatchAppsSyncer>((ref) {
   final appDao = ref.watch(appDaoProvider);
   final appInstallControl = ref.watch(appInstallControlProvider);
-  final connectionState = ref.watch(connectionStateProvider);
+  final connectionState = ref.watch(connectionStateProvider.notifier);
   final preferences = ref.read(preferencesProvider.future);
 
   return WatchAppsSyncer(

--- a/lib/infrastructure/datasources/dev_connection.dart
+++ b/lib/infrastructure/datasources/dev_connection.dart
@@ -158,9 +158,9 @@ class DevConnState {
   DevConnState(this.running, this.connected, this.localIp);
 }
 
-final devConnectionProvider = StateNotifierProvider<DevConnection>((ref) {
+final devConnectionProvider = StateNotifierProvider<DevConnection, DevConnState>((ref) {
   final incomingPacketsStream = ref.read(rawPacketStreamProvider);
-  final appManager = ref.read(appManagerProvider);
+  final appManager = ref.read(appManagerProvider.notifier);
   return DevConnection(incomingPacketsStream, appManager);
 });
 

--- a/lib/infrastructure/datasources/paired_storage.dart
+++ b/lib/infrastructure/datasources/paired_storage.dart
@@ -85,13 +85,13 @@ class PairedStorage extends StateNotifier<List<StoredDevice>> {
   }
 }
 
-final pairedStorageProvider = StateNotifierProvider((ref) => PairedStorage());
+final pairedStorageProvider = StateNotifierProvider<PairedStorage, List<StoredDevice>>((ref) => PairedStorage());
 final defaultWatchProvider = Provider((ref) => ref
-    .watch(pairedStorageProvider.state)
+    .watch(pairedStorageProvider)
     .firstWhereOrNull((element) => element.isDefault!)
     ?.device);
 final ProviderFamily<PebbleScanDevice, dynamic>? specificWatchProvider =
     Provider.family(((ref, dynamic address) => ref
-        .watch(pairedStorageProvider.state)
+        .watch(pairedStorageProvider)
         .firstWhereOrNull((element) => element.device.address == address)
         ?.device) as PebbleScanDevice Function(ProviderReference, dynamic));

--- a/lib/infrastructure/datasources/workarounds.dart
+++ b/lib/infrastructure/datasources/workarounds.dart
@@ -1,7 +1,6 @@
 import 'package:cobble/infrastructure/datasources/preferences.dart';
 import 'package:cobble/infrastructure/pigeons/pigeons.g.dart';
-import 'package:flutter/material.dart';
-import 'package:hooks_riverpod/all.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:rxdart/rxdart.dart';
 
 class Workaround {

--- a/lib/ui/devoptions/dev_options_page.dart
+++ b/lib/ui/devoptions/dev_options_page.dart
@@ -9,8 +9,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 class DevOptionsPage extends HookWidget implements CobbleScreen {
   @override
   Widget build(BuildContext context) {
-    final devConControl = useProvider(devConnectionProvider);
-    final devConnState = useProvider(devConnectionProvider.state);
+    final devConControl = useProvider(devConnectionProvider.notifier);
+    final devConnState = useProvider(devConnectionProvider);
 
     final preferences = useProvider(preferencesProvider);
     final bootUrl = useProvider(bootUrlProvider).data?.value ?? "";

--- a/lib/ui/devoptions/test_logs_page.dart
+++ b/lib/ui/devoptions/test_logs_page.dart
@@ -7,7 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 class TestLogsPage extends HookWidget implements CobbleScreen {
   @override
   Widget build(BuildContext context) {
-    final logs = useProvider(recievedLogsProvider.state);
+    final logs = useProvider(recievedLogsProvider);
 
     return ListView.builder(
         itemBuilder: (context, index) {

--- a/lib/ui/home/tabs/locker_tab.dart
+++ b/lib/ui/home/tabs/locker_tab.dart
@@ -6,30 +6,24 @@ import 'package:cobble/domain/entities/hardware_platform.dart';
 import 'package:cobble/localization/localization.dart';
 import 'package:cobble/ui/home/tabs/locker_tab/apps_item.dart';
 import 'package:cobble/ui/home/tabs/locker_tab/faces_card.dart';
-import 'package:cobble/ui/common/components/cobble_button.dart';
 import 'package:cobble/ui/common/components/cobble_divider.dart';
 import 'package:cobble/ui/common/components/cobble_fab.dart';
-import 'package:cobble/ui/common/components/cobble_sheet.dart';
-import 'package:cobble/ui/common/components/cobble_tile.dart';
 import 'package:cobble/ui/common/icons/fonts/rebble_icons.dart';
 import 'package:cobble/ui/router/cobble_scaffold.dart';
 import 'package:cobble/ui/router/cobble_screen.dart';
-import 'package:cobble/ui/theme/with_cobble_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_svg_provider/flutter_svg_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:share/share.dart';
 
 class LockerTab extends HookWidget implements CobbleScreen {
   @override
   Widget build(BuildContext context) {
-    final connectionState = useProvider(connectionStateProvider.state);
+    final connectionState = useProvider(connectionStateProvider);
 
     final currentWatch = connectionState.currentConnectedWatch;
 
-    final appManager = useProvider(appManagerProvider);
-    List allPackages = useProvider(appManagerProvider.state);
+    final appManager = useProvider(appManagerProvider.notifier);
+    List allPackages = useProvider(appManagerProvider);
     List incompatibleApps =
         allPackages.where((element) => !element.isWatchface).toList();
     List incompatibleFaces =

--- a/lib/ui/home/tabs/test_tab.dart
+++ b/lib/ui/home/tabs/test_tab.dart
@@ -1,5 +1,4 @@
 import 'package:cobble/domain/connection/connection_state_provider.dart';
-import 'package:cobble/domain/entities/hardware_platform.dart';
 import 'package:cobble/domain/permissions.dart';
 import 'package:cobble/infrastructure/datasources/paired_storage.dart';
 import 'package:cobble/infrastructure/datasources/preferences.dart';
@@ -27,7 +26,7 @@ class TestTab extends HookWidget implements CobbleScreen {
 
   @override
   Widget build(BuildContext context) {
-    final connectionState = useProvider(connectionStateProvider.state);
+    final connectionState = useProvider(connectionStateProvider);
     final defaultWatch = useProvider(defaultWatchProvider);
 
     final permissionControl = useProvider(permissionControlProvider);

--- a/lib/ui/home/tabs/watches_tab.dart
+++ b/lib/ui/home/tabs/watches_tab.dart
@@ -29,10 +29,10 @@ class MyWatchesTab extends HookWidget implements CobbleScreen {
 
   @override
   Widget build(BuildContext context) {
-    final connectionState = useProvider(connectionStateProvider.state);
+    final connectionState = useProvider(connectionStateProvider);
     final defaultWatch = useProvider(defaultWatchProvider);
-    final pairedStorage = useProvider(pairedStorageProvider);
-    final allWatches = useProvider(pairedStorageProvider.state);
+    final pairedStorage = useProvider(pairedStorageProvider.notifier);
+    final allWatches = useProvider(pairedStorageProvider);
     final preferencesFuture = useProvider(preferencesProvider.future);
 
     List<PebbleScanDevice> allWatchesList =

--- a/lib/ui/screens/calendar.dart
+++ b/lib/ui/screens/calendar.dart
@@ -18,8 +18,8 @@ class Calendar extends HookWidget implements CobbleScreen {
 
   @override
   Widget build(BuildContext context) {
-    final calendars = useProvider(calendarListProvider.state);
-    final calendarSelector = useProvider(calendarListProvider);
+    final calendars = useProvider(calendarListProvider);
+    final calendarSelector = useProvider(calendarListProvider.notifier);
     final calendarControl = useProvider(calendarControlProvider);
     final backgroundRpc = useProvider(backgroundRpcProvider);
 

--- a/lib/ui/screens/install_prompt.dart
+++ b/lib/ui/screens/install_prompt.dart
@@ -23,9 +23,9 @@ class InstallPrompt extends HookWidget implements CobbleScreen {
     final userInitiatedInstall = useState(false);
     final watchUploadHasStarted = useState(false);
 
-    final installStatus = useProvider(appInstallStatusProvider.state);
-    final appManager = useProvider(appManagerProvider);
-    final connectionStatus = useProvider(connectionStateProvider.state);
+    final installStatus = useProvider(appInstallStatusProvider);
+    final appManager = useProvider(appManagerProvider.notifier);
+    final connectionStatus = useProvider(connectionStateProvider);
 
     final connectedWatch = connectionStatus.currentConnectedWatch;
 

--- a/lib/ui/setup/pair_page.dart
+++ b/lib/ui/setup/pair_page.dart
@@ -50,8 +50,8 @@ class PairPage extends HookWidget implements CobbleScreen {
 
   @override
   Widget build(BuildContext context) {
-    final pairedStorage = useProvider(pairedStorageProvider);
-    final scan = useProvider(scanProvider.state);
+    final pairedStorage = useProvider(pairedStorageProvider.notifier);
+    final scan = useProvider(scanProvider);
     final pair = useProvider(pairProvider).data?.value;
     final preferences = useProvider(preferencesProvider);
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -278,7 +278,7 @@ packages:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.14.0+3"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -337,7 +337,7 @@ packages:
       name: hooks_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.14.0+3"
   http_multi_server:
     dependency: transitive
     description:
@@ -617,7 +617,7 @@ packages:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.14.0+3"
   rxdart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   sqflite: ^2.0.0+2
   package_info: ^2.0.0
   state_notifier: ^0.7.0
-  hooks_riverpod: ^0.13.0
+  hooks_riverpod: ^0.14.0
   flutter_hooks: ^0.16.0
   # We are using custom build of device_calendar with enhancements needed for Cobble app
   # pending PRs:


### PR DESCRIPTION
I'm trying to get up to speed with the codebase, and it's hard to learn how to use riverpod when the version we're using doesn't match the 1.0 version that the docs talk about. Unfortunately, updating to 1.0 will require updating a lot of other dependencies at the same time. I'm looking into doing that as well, but in the meantime this half step will reduce the diff of the full step later.

As mentioned, I'm not very familiar with riverpod, so it is very possible that I screwed something up here, so please review carefully. That being said, it seems likely that the compiler would have caught any errors in these particular modifications, thanks to strong typing, so I'm optimistic. 