### PR TITLE
iOS: Make current state compile and run

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -53,7 +53,6 @@
 		67B33CFA27C464B1007FBA39 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B33CE227C464B0007FBA39 /* AppDelegate.swift */; };
 		67B33CFB27C464B1007FBA39 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 67B33CE327C464B0007FBA39 /* GeneratedPluginRegistrant.m */; };
 		67C33E1E27CBBC2A005C14F2 /* PromiseKit in Frameworks */ = {isa = PBXBuildFile; productRef = 67C33E1D27CBBC2A005C14F2 /* PromiseKit */; };
-		67DE9ACF27D02F0100034816 /* 55b6528b5e07169e81000069.pbw in Resources */ = {isa = PBXBuildFile; fileRef = 67DE9ACD27D02EF000034816 /* 55b6528b5e07169e81000069.pbw */; };
 		67EB5FA327D2CE3C0072CE9D /* BackgroundAppInstallFlutterBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EB5FA227D2CE3C0072CE9D /* BackgroundAppInstallFlutterBridge.swift */; };
 		84544F477929DB68C98B9C52 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 620666896E8FA2E5FECAB423 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
@@ -130,7 +129,6 @@
 		67B33CE227C464B0007FBA39 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		67B33CE327C464B0007FBA39 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		67B33CE427C464B0007FBA39 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		67DE9ACD27D02EF000034816 /* 55b6528b5e07169e81000069.pbw */ = {isa = PBXFileReference; lastKnownFileType = file; name = 55b6528b5e07169e81000069.pbw; path = ../../../../Downloads/55b6528b5e07169e81000069.pbw; sourceTree = "<group>"; };
 		67EB5FA227D2CE3C0072CE9D /* BackgroundAppInstallFlutterBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundAppInstallFlutterBridge.swift; sourceTree = "<group>"; };
 		703F0CECA9F9B877FA874376 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -336,7 +334,6 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
-				67DE9ACD27D02EF000034816 /* 55b6528b5e07169e81000069.pbw */,
 				67B33CC027C464B0007FBA39 /* Runner */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				67945BA727C8140500DE13E8 /* cobbleTests */,
@@ -463,7 +460,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				67DE9ACF27D02F0100034816 /* 55b6528b5e07169e81000069.pbw in Resources */,
 				67B33CE827C464B1007FBA39 /* LaunchScreen.storyboard in Resources */,
 				67B33CE727C464B1007FBA39 /* Assets.xcassets in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -26,7 +26,6 @@ import Logging
         if #available(iOS 10.0, *) {
           UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
         }
-        FlutterBridgeSetup.createBackgroundBridges(binaryMessenger: binaryMessenger)
         FlutterBridgeSetup.createUIBridges(binaryMessenger: binaryMessenger)
         FlutterBridgeSetup.createCommonBridges(binaryMessenger: binaryMessenger)
         FlutterBackgroundController.shared = FlutterBackgroundController()

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -26,6 +26,7 @@ import Logging
         if #available(iOS 10.0, *) {
           UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
         }
+        FlutterBridgeSetup.createBackgroundBridges(binaryMessenger: binaryMessenger)
         FlutterBridgeSetup.createUIBridges(binaryMessenger: binaryMessenger)
         FlutterBridgeSetup.createCommonBridges(binaryMessenger: binaryMessenger)
         FlutterBackgroundController.shared = FlutterBackgroundController()

--- a/ios/Runner/bridges/FlutterBridgeSetup.swift
+++ b/ios/Runner/bridges/FlutterBridgeSetup.swift
@@ -22,10 +22,9 @@ class FlutterBridgeSetup {
     static func createBackgroundBridges(binaryMessenger: FlutterBinaryMessenger) {
         let backgroundSetupBridge = BackgroundSetupFlutterBridge()
 
-        // I am not super familiar with PromiseKit, I didn't know how to get rid of the unused return value of `.done`
-        _ = backgroundSetupBridge.waitForBackgroundHandle().done { handle in
-            FlutterBackgroundController.shared.setupEngine(handle)
-        }
+        backgroundSetupBridge.waitForBackgroundHandle().done {
+            FlutterBackgroundController.shared.setupEngine($0)
+        }.cauterize()
 
         BackgroundSetupControlSetup(binaryMessenger, backgroundSetupBridge)
     }

--- a/ios/Runner/bridges/FlutterBridgeSetup.swift
+++ b/ios/Runner/bridges/FlutterBridgeSetup.swift
@@ -10,6 +10,9 @@ import Flutter
 import PromiseKit
 
 class FlutterBridgeSetup {
+
+    // MARK: - Bridge Creation
+
     static func createCommonBridges(binaryMessenger: FlutterBinaryMessenger) {
         PermissionCheckSetup(binaryMessenger, PermissionCheckFlutterBridge())
         ScanControlSetup(binaryMessenger, ScanFlutterBridge(callbackMessenger: binaryMessenger))
@@ -20,19 +23,25 @@ class FlutterBridgeSetup {
     }
     
     static func createBackgroundBridges(binaryMessenger: FlutterBinaryMessenger) {
-        let backgroundSetupBridge = BackgroundSetupFlutterBridge()
-
-        backgroundSetupBridge.waitForBackgroundHandle().done {
-            FlutterBackgroundController.shared.setupEngine($0)
-        }.cauterize()
-
-        BackgroundSetupControlSetup(binaryMessenger, backgroundSetupBridge)
     }
-    
+
     static func createUIBridges(binaryMessenger: FlutterBinaryMessenger) {
+        BackgroundSetupControlSetup(binaryMessenger, backgroundSetupBridge)
         PermissionControlSetup(binaryMessenger, PermissionControlFlutterBridge())
         UiConnectionControlSetup(binaryMessenger, ConnectionControlBridge(callbackMessenger: binaryMessenger))
         IntentControlSetup(binaryMessenger, IntentControlFlutterBridge(callbackMessenger: binaryMessenger))
         WorkaroundsControlSetup(binaryMessenger, WorkaroundsFlutterBridge())
     }
+
+    // MARK: - BackgroundSetup Bridge
+
+    private static var backgroundSetupBridge: BackgroundSetupFlutterBridge = {
+        let bridge = BackgroundSetupFlutterBridge()
+
+        bridge.waitForBackgroundHandle().done {
+            FlutterBackgroundController.shared.setupEngine($0)
+        }.cauterize()
+
+        return bridge
+    }()
 }

--- a/ios/Runner/bridges/FlutterBridgeSetup.swift
+++ b/ios/Runner/bridges/FlutterBridgeSetup.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import Flutter
+import PromiseKit
+
 class FlutterBridgeSetup {
     static func createCommonBridges(binaryMessenger: FlutterBinaryMessenger) {
         PermissionCheckSetup(binaryMessenger, PermissionCheckFlutterBridge())
@@ -18,11 +20,17 @@ class FlutterBridgeSetup {
     }
     
     static func createBackgroundBridges(binaryMessenger: FlutterBinaryMessenger) {
-        
+        let backgroundSetupBridge = BackgroundSetupFlutterBridge()
+
+        // I am not super familiar with PromiseKit, I didn't know how to get rid of the unused return value of `.done`
+        _ = backgroundSetupBridge.waitForBackgroundHandle().done { handle in
+            FlutterBackgroundController.shared.setupEngine(handle)
+        }
+
+        BackgroundSetupControlSetup(binaryMessenger, backgroundSetupBridge)
     }
     
     static func createUIBridges(binaryMessenger: FlutterBinaryMessenger) {
-        BackgroundSetupControlSetup(binaryMessenger, BackgroundSetupFlutterBridge())
         PermissionControlSetup(binaryMessenger, PermissionControlFlutterBridge())
         UiConnectionControlSetup(binaryMessenger, ConnectionControlBridge(callbackMessenger: binaryMessenger))
         IntentControlSetup(binaryMessenger, IntentControlFlutterBridge(callbackMessenger: binaryMessenger))

--- a/ios/Runner/bridges/background/BackgroundAppInstallFlutterBridge.swift
+++ b/ios/Runner/bridges/background/BackgroundAppInstallFlutterBridge.swift
@@ -53,11 +53,6 @@ class BackgroundAppInstallFlutterBridge {
                 seal.fulfill(cachedAppInstallCallbacks)
             }else {
                 FlutterBackgroundController.shared.getBackgroundFlutterEngine().done { flutterEngine in
-                    guard let flutterEngine = flutterEngine else {
-                        seal.fulfill(nil)
-                        return
-                    }
-                    
                     seal.fulfill(BackgroundAppInstallCallbacks(binaryMessenger: flutterEngine.binaryMessenger))
                 }.catch { error in
                     seal.reject(error)

--- a/ios/Runner/bridges/background/FlutterBackgroundController.swift
+++ b/ios/Runner/bridges/background/FlutterBackgroundController.swift
@@ -20,9 +20,11 @@ class FlutterBackgroundController: NSObject, BackgroundControl {
     
     override init() {
         super.init()
-        initEngine().done { initedEngine in
-            self.engine = initedEngine
-        }.cauterize()
+        NotificationCenter.default.addObserver(forName: .abc, object: nil, queue: nil) { _ in
+            self.initEngine().done { initedEngine in
+                self.engine = initedEngine
+            }.cauterize()
+        }
     }
     
     func notifyFlutterBackgroundStarted(completion: @escaping (NumberWrapper?, FlutterError?) -> Void) {
@@ -61,7 +63,7 @@ class FlutterBackgroundController: NSObject, BackgroundControl {
                 if let callbackInfo = FlutterCallbackCache.lookupCallbackInformation(backgroundEndpointMethodHandle) {
                     flutterEngine.run(withEntrypoint: callbackInfo.callbackName, libraryURI: callbackInfo.callbackLibraryPath)
                 } else {
-                    flutterEngine.run()
+                    assertionFailure("Failed to initialize Flutter engine")
                 }
 
                 GeneratedPluginRegistrant.register(with: flutterEngine)

--- a/ios/Runner/bridges/background/FlutterBackgroundController.swift
+++ b/ios/Runner/bridges/background/FlutterBackgroundController.swift
@@ -37,7 +37,7 @@ class FlutterBackgroundController: NSObject, BackgroundControl {
         }
     }
 
-    func setupEngine(_ handle: Int64) {
+    func setupEngine(_ handle: CallbackHandle) {
         initEngine(callbackHandle: handle)
             .done { initedEngine in
                 DDLogDebug("Done initializing background engine")
@@ -49,7 +49,7 @@ class FlutterBackgroundController: NSObject, BackgroundControl {
             }
     }
     
-    private func initEngine(callbackHandle: Int64) -> Promise<FlutterEngine> {
+    private func initEngine(callbackHandle: CallbackHandle) -> Promise<FlutterEngine> {
         return Promise { seal in
             DispatchQueue.main.async { [self] in
                 let flutterEngine = FlutterEngine(name: "CobbleBG", project: nil, allowHeadlessExecution: true)

--- a/ios/Runner/bridges/ui/BackgroundSetupFlutterBridge.swift
+++ b/ios/Runner/bridges/ui/BackgroundSetupFlutterBridge.swift
@@ -12,14 +12,14 @@ typealias CallbackHandle = Int64
 
 class BackgroundSetupFlutterBridge: NSObject, BackgroundSetupControl {
 
-    private var resolver: Resolver<Int64>?
+    private var resolver: Resolver<CallbackHandle>?
 
-    func waitForBackgroundHandle() -> Promise<Int64> {
+    func waitForBackgroundHandle() -> Promise<CallbackHandle> {
         Promise { self.resolver = $0 }
     }
 
     func setupBackgroundCallbackHandle(_ callbackHandle: NumberWrapper, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
-        if let value = callbackHandle.value as? Int64 {
+        if let value = callbackHandle.value as? CallbackHandle {
             resolver?.fulfill(value)
         } else {
             error.pointee = .init(code: "INVALID_HANDLE", message: "setupBackgroundCallbackHandle called without a callback handle", details: nil)

--- a/ios/Runner/bridges/ui/BackgroundSetupFlutterBridge.swift
+++ b/ios/Runner/bridges/ui/BackgroundSetupFlutterBridge.swift
@@ -6,9 +6,16 @@
 //
 
 import Foundation
+
+extension NSNotification.Name {
+    static let abc = NSNotification.Name("abc")
+}
+
 class BackgroundSetupFlutterBridge: NSObject, BackgroundSetupControl {
     func setupBackgroundCallbackHandle(_ callbackHandle: NumberWrapper, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
         let persistentState = UserDefaults.standard
         persistentState.set(callbackHandle.value! as! Int64, forKey: "FlutterBackgroundHandle")
+
+        NotificationCenter.default.post(name: .abc, object: nil)
     }
 }

--- a/ios/Runner/bridges/ui/BackgroundSetupFlutterBridge.swift
+++ b/ios/Runner/bridges/ui/BackgroundSetupFlutterBridge.swift
@@ -22,7 +22,7 @@ class BackgroundSetupFlutterBridge: NSObject, BackgroundSetupControl {
         if let value = callbackHandle.value as? Int64 {
             resolver?.fulfill(value)
         } else {
-            error.pointee = .init(code: "code 123", message: "setupBackgroundCallbackHandle called without a handle", details: nil)
+            error.pointee = .init(code: "INVALID_HANDLE", message: "setupBackgroundCallbackHandle called without a callback handle", details: nil)
         }
     }
 }

--- a/ios/Runner/bridges/ui/PermissionControlFlutterBridge.swift
+++ b/ios/Runner/bridges/ui/PermissionControlFlutterBridge.swift
@@ -7,7 +7,17 @@
 
 import Foundation
 class PermissionControlFlutterBridge: NSObject, PermissionControl {
-    //TODO: finish impl
+
+    //TODO: are these Android only?
+    //  - requestBluetoothPermissions
+    //  - requestLocationPermission
+    //  - …
+    func requestBluetoothPermissions(completion: @escaping (NumberWrapper?, FlutterError?) -> Void) {
+        let num = NumberWrapper()
+        num.value = 0
+        completion(num, nil)
+    }
+
     func requestLocationPermission(completion: @escaping (NumberWrapper?, FlutterError?) -> Void) {
         let num = NumberWrapper()
         num.value = 0

--- a/ios/Runner/bridges/ui/PermissionControlFlutterBridge.swift
+++ b/ios/Runner/bridges/ui/PermissionControlFlutterBridge.swift
@@ -7,11 +7,7 @@
 
 import Foundation
 class PermissionControlFlutterBridge: NSObject, PermissionControl {
-
-    //TODO: are these Android only?
-    //  - requestBluetoothPermissions
-    //  - requestLocationPermission
-    //  - …
+    //TODO: finish impl
     func requestBluetoothPermissions(completion: @escaping (NumberWrapper?, FlutterError?) -> Void) {
         let num = NumberWrapper()
         num.value = 0


### PR DESCRIPTION
This pull request makes the app compile and run after checking out the `ios` branch:

- a reference to a non existing file had to be removed
- the _[PermissionControlFlutterBridge](https://github.com/pebble-dev/mobile-app/commit/699e350d26d79f4ca5b0133aabc1dba695a480ed)_ did not fully conform to _PermissionControl_
- fixes an issue where the Flutter engine is run without knowing the background callback handle

Closes #203 