### PR TITLE
Set the target branch for dependabot to rws

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    target-branch: "rws"
   - package-ecosystem: "gradle"
     directory: "/android"
     schedule:
       interval: "weekly"
-  
+    target-branch: "rws"


### PR DESCRIPTION
This should be reverted when rws branch is merged back into master