### PR TITLE
Add directory config for github-actions dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       interval: "weekly"
     target-branch: "rws"
   - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
     target-branch: "rws"


### PR DESCRIPTION
This is apparently mandatory