### PR TITLE
Fix typo in GitHub Actions workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        submodules: 'recursive'
+        with:
+          submodules: 'recursive'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/pull-android.yml
+++ b/.github/workflows/pull-android.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        submodules: 'recursive'
+        with:
+          submodules: 'recursive'
       - uses: actions/setup-java@v4
         with:
           java-version: '17'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        submodules: 'recursive'
+        with:
+          submodules: 'recursive'
       - uses: actions/setup-java@v4
         with:
           java-version: '17'


### PR DESCRIPTION
The commit https://github.com/pebble-dev/mobile-app/commit/74e174a39732b7e67623f8455a95c6e002e5ffee, set the workflow to grab submodules when checking out the repository, however the `submodules` parameter was specified as an argument to `jobs.build.steps[0]`, rather than `jobs.build.steps[0].with` (why GitHub decided to make their configuration format so confusing is unclear to me). After fixing this, nightlies build again*.

*In that it spits out a debug apk. I have not fixed any analyzer warnings or failing tests.