### PR TITLE
Fix notification channel muting

### DIFF
--- a/lib/ui/screens/alerting_app_details.dart
+++ b/lib/ui/screens/alerting_app_details.dart
@@ -51,7 +51,7 @@ class AlertingAppDetails extends HookConsumerWidget implements CobbleScreen {
                   child: Switch(
                     value: app.enabled,
                     onChanged: (value) async {
-                      var mutedPkgList = mutedPackages.value ?? [];
+                      var mutedPkgList = List<String>.from(mutedPackages.value ?? []);
                       if (value) {
                         mutedPkgList.removeWhere((element) => element == app.packageId);
                       }else {


### PR DESCRIPTION
mutedPackages is not mutable, so `.add` fails on a UnmodifiableListMixin exception.

Clone the list and mutate that instead.