### PR TITLE
truncate timezone ID only if it is too long

### DIFF
--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/handlers/SystemHandler.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/handlers/SystemHandler.kt
@@ -125,7 +125,7 @@ class SystemHandler(
    
         val normalizedZone = timezone.id
         if (normalizedZone.length > MAX_TIMEZONE_NAME_LENGTH) {
-            normalizedZone = timezone.id.take(MAX_TIMEZONE_NAME_LENGTH)
+            normalizedZone = normalizedZone.take(MAX_TIMEZONE_NAME_LENGTH)
             Logging.i("Time Zone ${timezone.id} exceeds maximum value length and has been truncated to ${normalizedZone}")
         }
         

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/handlers/SystemHandler.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/handlers/SystemHandler.kt
@@ -122,13 +122,20 @@ class SystemHandler(
         val timezone = TimeZone.currentSystemDefault()
         val now = Clock.System.now()
         val timezoneOffsetMinutes = timezone.offsetAt(now).totalSeconds.seconds.inWholeMinutes
-        Logging.i("Sending current time to watch: $now, timezone: ${timezone.id} (truncated: ${timezone.id.take(MAX_TIMEZONE_NAME_LENGTH)}), offset: $timezoneOffsetMinutes")
+   
+        val normalizedZone = timezone.id
+        if (normalizedZone.length > MAX_TIMEZONE_NAME_LENGTH) {
+            normalizedZone = timezone.id.take(MAX_TIMEZONE_NAME_LENGTH)
+            Logging.i("Time Zone ${timezone.id} exceeds maximum value length and has been truncated to ${normalizedZone}")
+        }
+        
         val updateTimePacket = TimeMessage.SetUTC(
                 now.epochSeconds.toUInt(),
                 timezoneOffsetMinutes.toShort(),
-                timezone.id.take(MAX_TIMEZONE_NAME_LENGTH)
+                normalizedZone
         )
 
+        Logging.i("Sending current time to watch: $now, timezone: ${normalizedZone}, offset: $timezoneOffsetMinutes")
         systemService.send(updateTimePacket)
     }
 


### PR DESCRIPTION
This is attempt at improving the efficiency and readability of the recently introduced Time Zone truncation code and its accompanying logs. 

The current code in `master` will always be calling `timezone.id.take(MAX_TIMEZONE_NAME_LENGTH)` twice, for all Time Zones:

1. To log the expected output before populating the packet to be sent to the watch
2. When actually populating the packet

The proposed code enforces consistency between the log and the packet sent to the watch, and only does costly String operations when absolutely necessary, by checking the length against the maximum. 