### PR TITLE
Fix Java 21 issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ If you do not have an IDE, from step 5, you'll instead:
 2. Launch an emulator: `fvm flutter emulators --launch Pixel_2_API_30`
 3. `fvm flutter run`
 
-If you get the `Unknown Kotlin JVM target: 21` error while trying to build the app, you probably have wrong JDK version.
-
-Install JDK 17 and update flutter config to point to this JDK:
-```bash
-fvm flutter config --jdk-dir <path-to-jdk-17>
-```
-
 ### Host-specific instructions: Ubuntu and similar
 
 To install FVM on Ubuntu, try something like:

--- a/android/buildSrc/build.gradle.kts
+++ b/android/buildSrc/build.gradle.kts
@@ -5,3 +5,7 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+kotlin {
+    jvmToolchain(17)
+}


### PR DESCRIPTION
Instead of adding a manual fix for the Java 21 error, we can just enforce using Java 17 in the build gradle