### PR TITLE
Make sure all gradle files are pulling dependencies from the Version Catalog

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -115,31 +115,21 @@ project.extensions.getByName("flutter").apply {
     this::class.java.getMethod("source", String::class.java).invoke(this, "../..")
 }
 
-val coroutinesVersion = "1.8.1"
-val lifecycleVersion = "2.8.2"
-val timberVersion = "5.0.1"
-val androidxCoreVersion = "1.13.1"
-val workManagerVersion = "2.9.0"
-val okioVersion = "3.9.0"
-
-val junitVersion = "4.13.2"
-val androidxTestVersion = "1.5.0"
-
 dependencies {
     implementation(libs.androidx.appcompat)
     api(libs.androidx.activity.compose)
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    coreLibraryDesugaring(libs.desugar)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.libpebblecommon)
     implementation(libs.kotlin.reflect)
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion")
-    implementation("androidx.lifecycle:lifecycle-service:$lifecycleVersion")
-    implementation("com.jakewharton.timber:timber:$timberVersion")
-    implementation("androidx.core:core-ktx:$androidxCoreVersion")
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.livedata.ktx)
+    implementation(libs.androidx.lifecycle.service)
+    implementation(libs.timber)
+    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.work.runtime.ktx)
-    implementation("com.squareup.okio:okio:$okioVersion")
+    implementation(libs.okio)
     implementation(libs.androidx.room.runtime)
     implementation(libs.kotlinx.datetime)
     implementation(libs.dagger)
@@ -151,9 +141,9 @@ dependencies {
     implementation(project(":shared"))
     kapt(libs.dagger.compiler)
 
-    testImplementation("junit:junit:$junitVersion")
-    androidTestImplementation("androidx.test:runner:$androidxTestVersion")
-    androidTestImplementation("androidx.test:rules:$androidxTestVersion")
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.rules)
 }
 
 android.buildTypes.getByName("release").ndk.debugSymbolLevel = "FULL"

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -2,9 +2,12 @@
 activityCompose = "1.9.3"
 android-minSdk = "29"
 android-targetSdk = "34"
+androidxLifecycle = "2.8.2"
 androidxVersion = "1.15.0"
+ble = "1.0.16"
 coroutinesVersion = "1.8.1"
 daggerVersion = "2.51.1"
+desugar = "2.0.4"
 gradle = "8.7.2"
 koinVersion = "4.0.0"
 kotlin = "2.1.0-RC"
@@ -13,7 +16,11 @@ kotlinxSerializationJson = "1.7.1"
 ksp = "2.1.0-RC-1.0.27"
 libpebblecommonVersion = "0.1.27"
 errorproneVersion = "2.26.1"
+logbackAndroid = "3.0.0"
+mockk = "1.13.11"
+okio = "3.9.0"
 rruleVersion = "1.0.3"
+slf4jApi = "2.0.9"
 spotbugsVersion = "4.8.6"
 atomicfu = "0.25.0"
 securityCrypto = "1.1.0-alpha06"
@@ -55,17 +62,27 @@ jetbrains-kotlinx-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.re
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxVersion" }
+androidx-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "androidxLifecycle" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxTest" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTest" }
 androidx-test-monitor = { module = "androidx.test:monitor", version.ref = "androidxTest" }
 androidx-security-crypto-ktx = { module = "androidx.security:security-crypto-ktx", version.ref = "securityCrypto" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workManagerVersion" }
+ble-core = { module = "no.nordicsemi.android.kotlin.ble:core", version.ref = "ble" }
+ble-server = { module = "no.nordicsemi.android.kotlin.ble:server", version.ref = "ble" }
 dagger = { module = "com.google.dagger:dagger", version.ref = "daggerVersion" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "daggerVersion" }
+desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 kgp = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorproneVersion" }
+logback-android = { module = "com.github.tony19:logback-android", version.ref = "logbackAndroid" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 rrule = { module = "com.github.PhilJay:RRule", version.ref = "rruleVersion" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4jApi" }
 spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugsVersion" }
 
 androidx-sqlite = { module = "androidx.sqlite:sqlite", version.ref = "room-sqlite" }
@@ -81,6 +98,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutinesVersion" }
 kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "coroutinesVersion" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutinesVersion" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesVersion" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationJson" }

--- a/android/pebble_bt_transport/build.gradle.kts
+++ b/android/pebble_bt_transport/build.gradle.kts
@@ -33,37 +33,31 @@ android {
     }
 }
 
-val timberVersion = "4.7.1"
-val coroutinesVersion = "1.8.0"
-val okioVersion = "3.7.0"
-val mockkVersion = "1.13.11"
-val nordicBleVersion = "1.0.16"
-
 dependencies {
-    implementation("androidx.core:core-ktx:1.13.1")
-    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
     implementation(libs.libpebblecommon)
-    implementation("com.jakewharton.timber:timber:$timberVersion")
+    implementation(libs.timber)
     // for nordic ble
-    implementation("org.slf4j:slf4j-api:2.0.9")
-    implementation("com.github.tony19:logback-android:3.0.0")
+    implementation(libs.slf4j.api)
+    implementation(libs.logback.android)
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
-    implementation("com.squareup.okio:okio:$okioVersion")
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.okio)
     implementation(libs.kotlinx.serialization.json)
 
 
 
-    implementation("no.nordicsemi.android.kotlin.ble:core:$nordicBleVersion")
-    implementation("no.nordicsemi.android.kotlin.ble:server:$nordicBleVersion")
+    implementation(libs.ble.core)
+    implementation(libs.ble.server)
     implementation(project(":shared"))
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
-    testImplementation("io.mockk:mockk:$mockkVersion")
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation("androidx.test:rules:1.5.0")
-    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
 }

--- a/android/shared/build.gradle.kts
+++ b/android/shared/build.gradle.kts
@@ -12,10 +12,6 @@ plugins {
     alias(libs.plugins.jetbrains.kotlinx.atomicfu)
 }
 
-val timberVersion = "5.0.1"
-val androidxVersion = "1.13.1"
-val rruleVersion = "1.0.3"
-
 kotlin {
     androidTarget {
         compilations.all {


### PR DESCRIPTION
I added some dependencies in #320 and noticed some build files used the Version catalog for all dependencies while some didn't. I updated all the build files to consistently use the Version Catalog for declaring and referencing dependencies. 