### PR TITLE
Disable Jetifier

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx4G --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
Jetifier is slow ([1](https://developer.android.com/build/optimize-your-build#disable-the-jetifier-flag) & [2](https://adambennett.dev/2020/08/disabling-jetifier/)) and doesn't seem used anymore so this PR just disables it. 