### PR TITLE
Enable Gradle Build cache and building modules in parallel

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -5,6 +5,7 @@ android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 org.gradle.parallel=true
+org.gradle.caching=true
 kotlin.code.style=official
 kotlin.native.disableCompilerDaemon = true
 kapt.use.k2=false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,6 +4,7 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+org.gradle.parallel=true
 kotlin.code.style=official
 kotlin.native.disableCompilerDaemon = true
 kapt.use.k2=false


### PR DESCRIPTION
Gradle supports [building modules in parallel ](https://docs.gradle.org/current/userguide/performance.html#parallel_execution) as well as avoiding rebuilding modules when nothing in them changes via[ the build cache feature](https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_intro). 

This PR enables both of those features. Right now any improvements from these features is pretty minimal but as the project grows and potentially moduralizes more these provide a large benefit. 