### PR TITLE
Fix broken AppstoreClientTest test

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koinVersion" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koinVersion" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koinVersion" }
+koin-test = { module = "io.insert-koin:koin-test", version.ref = "koinVersion" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutinesVersion" }
 kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "coroutinesVersion" }

--- a/android/shared/build.gradle.kts
+++ b/android/shared/build.gradle.kts
@@ -86,6 +86,7 @@ kotlin {
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.ktor.client.mock)
+            implementation(libs.koin.test)
         }
     }
     room {


### PR DESCRIPTION
I was trying to add tests for something else but quickly realized I couldn't run `./gradlew test` 😅 

Fixed `Get locker data` in `AppstoreClientTest` by making it a `KoinTest` an providing an instance of `HttpClient` to the Koin DI graph since it's being implicitly depended on in `AppstoreClient`. 