### PR TITLE
android: Fix IntentFilter to not match all URLs

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -101,9 +101,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="content" />
-                <data android:mimeType="*/*" />
-                <data android:pathPattern=".*\\.pbw" />
+                <data android:scheme="content" android:pathSuffix=".pbw" />
             </intent-filter>
         </activity>
 
@@ -168,9 +166,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="content" />
-                <data android:mimeType="*/*" />
-                <data android:pathPattern=".*\\.pbz" />
+                <data android:scheme="content" android:pathSuffix=".pbz" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.


### PR DESCRIPTION
Intent filters can match on the data of an intent through the <data> tag. When multiple tags are present, they act as a boolean OR, intended if you want to match multiple data types. When a boolean AND is required, the attributes should instead be added to a single <data> tag.

Two of our intent filters try to match ".pbw" and ".pbz" files. These both start with a single match on the "content" schema, followed by a match on the "*/*" MIME type, and finally a path filter for the file type in question. By virtue of being boolean OR, this meant that both filters would match every possible URL.

Combine the attributes in a single data tag to turn it into a boolean AND for both of these filters.