### PR TITLE
editorconfig: Exempt commit messages from line length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,9 @@ ij_formatter_tags_enabled = false
 ij_smart_tabs = false
 ij_wrap_on_typing = false
 
+[/.git/**]
+max_line_length = unset
+
 [*.dart]
 max_line_length = 80
 


### PR DESCRIPTION
When an .editorconfig sets a line length on [*], it also ends up affecting the temporary commit message file (.git/COMMIT_EDITMSG), overriding the standard git commit line length limits.

Explicitly unset the line length for the .git folder.