### PR TITLE
Create KMP settings screen

### DIFF
--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/nav/Routes.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/nav/Routes.kt
@@ -4,6 +4,7 @@ object Routes {
     const val DIALOG_APP_INSTALL = "dialog_app_install"
     object Home {
         const val LOCKER_APPS = "locker_apps"
+        const val SETTINGS = "settings"
         const val LOCKER_WATCHFACES = "locker_watchfaces"
         const val TEST_PAGE = "test_page"
     }

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/MainView.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/MainView.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.navigation.NamedNavArgument
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -20,8 +19,6 @@ import io.rebble.cobble.shared.ui.view.dialogs.AppInstallDialog
 import io.rebble.cobble.shared.ui.view.home.HomePage
 import io.rebble.cobble.shared.ui.view.home.HomeScaffold
 import io.rebble.cobble.shared.ui.view.home.locker.LockerTabs
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.Json.Default.decodeFromString
 import org.koin.compose.KoinContext
 
 @Composable
@@ -45,6 +42,9 @@ fun MainView(navController: NavHostController = rememberNavController()) {
                         }
                         composable(Routes.Home.TEST_PAGE) {
                             HomeScaffold(HomePage.TestPage, onNavChange = navController::navigate)
+                        }
+                        composable(Routes.Home.SETTINGS) {
+                            HomeScaffold(HomePage.Settings, onNavChange = navController::navigate)
                         }
                         dialog("${Routes.DIALOG_APP_INSTALL}?uri={uri}", arguments = listOf(navArgument("uri") {
                             nullable = false

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/HomeScaffold.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/HomeScaffold.kt
@@ -15,11 +15,13 @@ import io.rebble.cobble.shared.ui.common.RebbleIcons
 import io.rebble.cobble.shared.ui.nav.Routes
 import io.rebble.cobble.shared.ui.view.home.locker.Locker
 import io.rebble.cobble.shared.ui.view.home.locker.LockerTabs
+import io.rebble.cobble.shared.ui.view.home.settings.Settings
 import kotlinx.coroutines.launch
 
 open class HomePage {
     class Locker(val tab: LockerTabs) : HomePage()
     object TestPage : HomePage()
+    object Settings: HomePage()
 }
 
 @Composable
@@ -50,6 +52,13 @@ fun HomeScaffold(page: HomePage, onNavChange: (String) -> Unit) {
                     onClick = { onNavChange(Routes.Home.LOCKER_WATCHFACES) },
                     icon = { RebbleIcons.locker() },
                     label = { Text("Locker") }
+                )
+
+                NavigationBarItem(
+                        selected = page is HomePage.Settings,
+                        onClick = { onNavChange(Routes.Home.SETTINGS) },
+                        icon = { RebbleIcons.settings() },
+                        label = { Text("Settings") }
                 )
             }
         },
@@ -84,6 +93,7 @@ fun HomeScaffold(page: HomePage, onNavChange: (String) -> Unit) {
                         }
                     })
                 }
+                is HomePage.Settings -> Settings(onNavigate = onNavChange)
             }
         }
     }

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/Settings.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/Settings.kt
@@ -1,15 +1,50 @@
 package io.rebble.cobble.shared.ui.view.home.settings
 
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import io.rebble.cobble.shared.ui.common.RebbleIcons
+import io.rebble.cobble.shared.ui.viewmodel.SettingsViewModel
 
 
 @Composable
-fun Settings(
-        onNavigate: (String) -> Unit,
-        modifier: Modifier = Modifier
-) {
+fun Settings(viewModel: SettingsViewModel = viewModel(), onNavigate: (String) -> Unit, modifier: Modifier = Modifier) {
+    Settings(settings = viewModel.settings, onNavigate = { /* TODO setup navigation in later PR */ }, modifier = modifier)
+}
 
-    Text(text = "Settings!")
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun Settings(settings: List<SettingsViewModel.SettingsNavigationItem>, onNavigate: (String) -> Unit, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        CenterAlignedTopAppBar(title = { Text("Settings") })
+        Column(modifier.verticalScroll(rememberScrollState())) {
+            settings.forEach { item ->
+                if (item.icon == SettingsViewModel.SettingsNavigationItem.SettingsIcons.DEVELOPER) {
+                    HorizontalDivider(thickness = 2.dp)
+                }
+                SettingsNavigableListItem(
+                        icon = {
+                            when (item.icon) {
+                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.NOTIFICATIONS -> RebbleIcons.notification()
+                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.HEALTH -> RebbleIcons.healthHeart()
+                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.CALENDAR -> RebbleIcons.calendar()
+                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.MESSAGES -> RebbleIcons.smsMessages()
+                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.LANGUAGE -> RebbleIcons.systemLanguage()
+                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.ANALYTICS -> RebbleIcons.analytics()
+                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.ABOUT -> RebbleIcons.aboutApp()
+                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.DEVELOPER -> RebbleIcons.developerSettings()
+                            }
+                        },
+                        title = item.title,
+                        onClick = { onNavigate(item.navigation) }
+                )
+            }
+            Spacer(modifier = Modifier.fillMaxWidth().height(16.dp))
+        }
+    }
 }

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/Settings.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/Settings.kt
@@ -19,7 +19,7 @@ fun Settings(viewModel: SettingsViewModel = viewModel(), onNavigate: (String) ->
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun Settings(settings: List<SettingsViewModel.SettingsNavigationItem>, onNavigate: (String) -> Unit, modifier: Modifier = Modifier) {
+fun Settings(settings: List<SettingsViewModel.SettingsNavigationItem>, onNavigate: (String) -> Unit, modifier: Modifier = Modifier) {
     Column(modifier = modifier) {
         CenterAlignedTopAppBar(title = { Text("Settings") })
         Column(modifier.verticalScroll(rememberScrollState())) {

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/Settings.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/Settings.kt
@@ -24,22 +24,11 @@ fun Settings(settings: List<SettingsViewModel.SettingsNavigationItem>, onNavigat
         CenterAlignedTopAppBar(title = { Text("Settings") })
         Column(modifier.verticalScroll(rememberScrollState())) {
             settings.forEach { item ->
-                if (item.icon == SettingsViewModel.SettingsNavigationItem.SettingsIcons.DEVELOPER) {
+                if (item.containsTopDivider) {
                     HorizontalDivider(thickness = 2.dp)
                 }
                 SettingsNavigableListItem(
-                        icon = {
-                            when (item.icon) {
-                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.NOTIFICATIONS -> RebbleIcons.notification()
-                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.HEALTH -> RebbleIcons.healthHeart()
-                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.CALENDAR -> RebbleIcons.calendar()
-                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.MESSAGES -> RebbleIcons.smsMessages()
-                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.LANGUAGE -> RebbleIcons.systemLanguage()
-                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.ANALYTICS -> RebbleIcons.analytics()
-                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.ABOUT -> RebbleIcons.aboutApp()
-                                SettingsViewModel.SettingsNavigationItem.SettingsIcons.DEVELOPER -> RebbleIcons.developerSettings()
-                            }
-                        },
+                        icon = item.icon,
                         title = item.title,
                         onClick = { onNavigate(item.navigation) }
                 )

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/Settings.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/Settings.kt
@@ -1,0 +1,15 @@
+package io.rebble.cobble.shared.ui.view.home.settings
+
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+
+@Composable
+fun Settings(
+        onNavigate: (String) -> Unit,
+        modifier: Modifier = Modifier
+) {
+
+    Text(text = "Settings!")
+}

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/SettingsNavigableListItem.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/view/home/settings/SettingsNavigableListItem.kt
@@ -1,0 +1,23 @@
+package io.rebble.cobble.shared.ui.view.home.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.rebble.cobble.shared.ui.common.RebbleIcons
+
+@Composable
+internal fun SettingsNavigableListItem(
+        icon: @Composable () -> Unit,
+        title: String,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier
+) {
+    ListItem(
+            modifier = modifier.clickable(onClick = onClick),
+            leadingContent = icon,
+            headlineContent = { Text(text = title) },
+            trailingContent = { RebbleIcons.caretRight() }
+    )
+}

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/viewmodel/SettingsViewModel.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/viewmodel/SettingsViewModel.kt
@@ -1,0 +1,66 @@
+package io.rebble.cobble.shared.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+class SettingsViewModel : ViewModel() {
+
+    val settings: List<SettingsNavigationItem> = listOf(
+            SettingsNavigationItem(
+                    icon = SettingsNavigationItem.SettingsIcons.NOTIFICATIONS,
+                    title = "Notification",
+                    navigation = "notification_settings",
+            ),
+            SettingsNavigationItem(
+                    icon = SettingsNavigationItem.SettingsIcons.HEALTH,
+                    title = "Health",
+                    navigation = "health_settings",
+            ),
+            SettingsNavigationItem(
+                    icon = SettingsNavigationItem.SettingsIcons.CALENDAR,
+                    title = "Calendar",
+                    navigation = "calendar_settings",
+            ),
+            SettingsNavigationItem(
+                    icon = SettingsNavigationItem.SettingsIcons.MESSAGES,
+                    title = "Messages and canned replies",
+                    navigation = "messages_settings",
+            ),
+            SettingsNavigationItem(
+                    icon = SettingsNavigationItem.SettingsIcons.LANGUAGE,
+                    title = "Language and dictation",
+                    navigation = "language_settings",
+            ),
+            SettingsNavigationItem(
+                    icon = SettingsNavigationItem.SettingsIcons.ANALYTICS,
+                    title = "Analytics",
+                    navigation = "analytics_settings",
+            ),
+            SettingsNavigationItem(
+                    icon = SettingsNavigationItem.SettingsIcons.ABOUT,
+                    title = "About and support",
+                    navigation = "about_settings",
+            ),
+            SettingsNavigationItem(
+                    icon = SettingsNavigationItem.SettingsIcons.DEVELOPER,
+                    title = "Developer tools",
+                    navigation = "developer_settings",
+            ),
+    )
+
+    data class SettingsNavigationItem(
+            val icon: SettingsIcons,
+            val title: String,
+            val navigation: String,
+    ) {
+        enum class SettingsIcons {
+            NOTIFICATIONS,
+            HEALTH,
+            CALENDAR,
+            MESSAGES,
+            LANGUAGE,
+            ANALYTICS,
+            ABOUT,
+            DEVELOPER,
+        }
+    }
+}

--- a/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/viewmodel/SettingsViewModel.kt
+++ b/android/shared/src/commonMain/kotlin/io/rebble/cobble/shared/ui/viewmodel/SettingsViewModel.kt
@@ -1,66 +1,59 @@
 package io.rebble.cobble.shared.ui.viewmodel
 
+import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
+import io.rebble.cobble.shared.ui.common.RebbleIcons
 
 class SettingsViewModel : ViewModel() {
 
     val settings: List<SettingsNavigationItem> = listOf(
             SettingsNavigationItem(
-                    icon = SettingsNavigationItem.SettingsIcons.NOTIFICATIONS,
+                    icon = { RebbleIcons.notification() },
                     title = "Notification",
                     navigation = "notification_settings",
             ),
             SettingsNavigationItem(
-                    icon = SettingsNavigationItem.SettingsIcons.HEALTH,
+                    icon = { RebbleIcons.healthHeart() },
                     title = "Health",
                     navigation = "health_settings",
             ),
             SettingsNavigationItem(
-                    icon = SettingsNavigationItem.SettingsIcons.CALENDAR,
+                    icon = { RebbleIcons.calendar() },
                     title = "Calendar",
                     navigation = "calendar_settings",
             ),
             SettingsNavigationItem(
-                    icon = SettingsNavigationItem.SettingsIcons.MESSAGES,
+                    icon = { RebbleIcons.smsMessages() },
                     title = "Messages and canned replies",
                     navigation = "messages_settings",
             ),
             SettingsNavigationItem(
-                    icon = SettingsNavigationItem.SettingsIcons.LANGUAGE,
+                    icon = { RebbleIcons.systemLanguage() },
                     title = "Language and dictation",
                     navigation = "language_settings",
             ),
             SettingsNavigationItem(
-                    icon = SettingsNavigationItem.SettingsIcons.ANALYTICS,
+                    icon = { RebbleIcons.analytics() },
                     title = "Analytics",
                     navigation = "analytics_settings",
             ),
             SettingsNavigationItem(
-                    icon = SettingsNavigationItem.SettingsIcons.ABOUT,
+                    icon = { RebbleIcons.aboutApp() },
                     title = "About and support",
                     navigation = "about_settings",
             ),
             SettingsNavigationItem(
-                    icon = SettingsNavigationItem.SettingsIcons.DEVELOPER,
+                    icon = { RebbleIcons.developerSettings() },
                     title = "Developer tools",
                     navigation = "developer_settings",
+                    containsTopDivider = true
             ),
     )
 
     data class SettingsNavigationItem(
-            val icon: SettingsIcons,
+            val icon: @Composable () -> Unit,
             val title: String,
             val navigation: String,
-    ) {
-        enum class SettingsIcons {
-            NOTIFICATIONS,
-            HEALTH,
-            CALENDAR,
-            MESSAGES,
-            LANGUAGE,
-            ANALYTICS,
-            ABOUT,
-            DEVELOPER,
-        }
-    }
+            val containsTopDivider: Boolean = false,
+    )
 }


### PR DESCRIPTION
Part 1 of a couple for #304.  This just focused on setting up a placeholder Settings screen, later PRs will add the Account card and make each item navigable. Trying to get this in while I work on the Account card which I think will be a little more complicated 😅 

[Figma](https://www.figma.com/design/mXl0svBSnlGV2MKfTj8H7e/Rebble-App%2FCobble-Layouts-and-Prototype?node-id=1540-0&t=6NDt6cAHmoZCO96Y-4)


![Screenshot_20250303_193056](https://github.com/user-attachments/assets/6a747729-d805-41d5-b620-388a12446aa9)
