### PR TITLE
Ensure all modules compile and target SDK 35

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 activityCompose = "1.9.3"
 android-minSdk = "29"
-android-targetSdk = "34"
+android-targetSdk = "35"
 androidxLifecycle = "2.8.2"
 androidxVersion = "1.15.0"
 ble = "1.0.16"

--- a/android/pebble_bt_transport/build.gradle.kts
+++ b/android/pebble_bt_transport/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.example.pebble_ble"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()

--- a/android/pebblekit_android/build.gradle.kts
+++ b/android/pebblekit_android/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.getpebble.android.kit"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 29

--- a/android/shared/src/androidMain/kotlin/io/rebble/cobble/shared/handlers/music/ActiveMediaSessionProvider.kt
+++ b/android/shared/src/androidMain/kotlin/io/rebble/cobble/shared/handlers/music/ActiveMediaSessionProvider.kt
@@ -122,7 +122,7 @@ class ActiveMediaSessionProvider :
             }
         }
 
-        override fun onAudioInfoChanged(info: MediaController.PlaybackInfo?) {
+        override fun onAudioInfoChanged(playbackInfo: MediaController.PlaybackInfo) {
             updateControllerIfNeeded()
         }
     }

--- a/android/shared/src/androidMain/kotlin/io/rebble/cobble/shared/handlers/music/MusicHandler.kt
+++ b/android/shared/src/androidMain/kotlin/io/rebble/cobble/shared/handlers/music/MusicHandler.kt
@@ -82,7 +82,7 @@ class MusicHandler(private val pebbleDevice: PebbleDevice): CobbleHandler, KoinC
         val name = packageManager
                 .getPackageInfo(mediaController.packageName, 0)
                 .applicationInfo
-                .loadLabel(packageManager)
+                ?.loadLabel(packageManager)
                 .toString()
 
         if (!musicControl.tryEmit(MusicControl.UpdatePlayerInfo(name, mediaController.packageName))) {

--- a/android/speex_codec/build.gradle.kts
+++ b/android/speex_codec/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.example.speex_codec"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 29


### PR DESCRIPTION
While working on #338 I ran into a some compilation issues when trying to run detekt on the whole codebase as certain modules were trying to use dependencies that compiled with SDK 35 (Androidx.core-ktx and WorkManager) despite themselves not compiling/targeting SDK 35. The App module already compiles/targets SDK 35 so this shouldn't have any functional changes it just alleviates a build issue.  