### PR TITLE
Expose pebblekit_android as an API dependency for the shared module

### DIFF
--- a/android/shared/build.gradle.kts
+++ b/android/shared/build.gradle.kts
@@ -77,7 +77,7 @@ kotlin {
             implementation(libs.timber)
             implementation(libs.rrule)
             implementation(libs.androidx.security.crypto.ktx)
-            implementation(project(":pebblekit_android"))
+            api(project(":pebblekit_android"))
             implementation(project(":speex_codec"))
         }
         commonTest.dependencies {


### PR DESCRIPTION
Trying to run `./gradlew app:test` would fail with a compilation issue pointing to not being able to access a class in the pebblekit_android module.


<img width="1751" alt="Screenshot 2025-03-01 at 10 58 18 PM" src="https://github.com/user-attachments/assets/0b8ae3f1-f6f1-41e5-905a-48bbd68df65a" />



